### PR TITLE
Update php_eggs.py - Change long description plugin

### DIFF
--- a/plugins/infrastructure/php_eggs.py
+++ b/plugins/infrastructure/php_eggs.py
@@ -357,7 +357,7 @@ class php_eggs(InfrastructurePlugin):
         ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
         ("50caaf268b4f3d260d720a1a29c5fe21", "PHP Logo 2"),
         ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
-    EGG_DB["5.1.5"] = [
+    EGG_DB["5.1.6"] = [
         ("82fa2d6aa15f971f7dadefe4f2ac20e3", "PHP Credits"),
         ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
         ("50caaf268b4f3d260d720a1a29c5fe21", "PHP Logo 2"),
@@ -391,6 +391,11 @@ class php_eggs(InfrastructurePlugin):
         ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
         ("50caaf268b4f3d260d720a1a29c5fe21", "PHP Logo 2"),
         ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.2.3"] = [
+        ("c37c96e8728dc959c55219d47f2d543f", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("50caaf268b4f3d260d720a1a29c5fe21", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
     EGG_DB["5.2.3-1+b1"] = [
         ("c37c96e8728dc959c55219d47f2d543f", "PHP Credits"),
         ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
@@ -401,11 +406,6 @@ class php_eggs(InfrastructurePlugin):
         ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
         ("50caaf268b4f3d260d720a1a29c5fe21", "PHP Logo 2"),
         ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
-    EGG_DB["5.2.5"] = [
-        ("f26285281120a2296072f21e21e7b4b0", "PHP Credits"),
-        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
-        ("50caaf268b4f3d260d720a1a29c5fe21", "PHP Logo 2"),
-        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
     EGG_DB["5.2.4-2ubuntu5.3"] = [
         ("f26285281120a2296072f21e21e7b4b0", "PHP Credits"),
         ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
@@ -413,6 +413,16 @@ class php_eggs(InfrastructurePlugin):
         ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
     EGG_DB["5.2.4-2ubuntu5.14"] = [
         ("c37c96e8728dc959c55219d47f2d543f", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("50caaf268b4f3d260d720a1a29c5fe21", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.2.5"] = [
+        ("c37c96e8728dc959c55219d47f2d543f", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("50caaf268b4f3d260d720a1a29c5fe21", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.2.5"] = [
+        ("f26285281120a2296072f21e21e7b4b0", "PHP Credits"),
         ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
         ("50caaf268b4f3d260d720a1a29c5fe21", "PHP Logo 2"),
         ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
@@ -431,11 +441,21 @@ class php_eggs(InfrastructurePlugin):
         ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
         ("50caaf268b4f3d260d720a1a29c5fe21", "PHP Logo 2"),
         ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
-    EGG_DB['5.2.8-pl1-gentoo'] = [
-        ('c48b07899917dfb5d591032007041ae3', 'PHP Logo'),
-        ('40410284d460552a6c9e10c1f5ae7223', 'PHP Credits'),
-        ('50caaf268b4f3d260d720a1a29c5fe21', 'PHP Logo 2'),
-        ('7675f1d01c927f9e6a4752cf182345a2', 'Zend Logo')]
+    EGG_DB["5.2.7"] = [
+        ("1ffc970c5eae684bebc0e0133c4e1f01", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("50caaf268b4f3d260d720a1a29c5fe21", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.2.8"] = [
+        ("1ffc970c5eae684bebc0e0133c4e1f01", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("50caaf268b4f3d260d720a1a29c5fe21", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.2.8-pl1-gentoo"] = [
+        ("40410284d460552a6c9e10c1f5ae7223", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("50caaf268b4f3d260d720a1a29c5fe21", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
     EGG_DB["5.2.9"] = [
         ("54f426521bf61f2d95c8bfaa13857c51", "PHP Credits"),
         ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
@@ -446,13 +466,33 @@ class php_eggs(InfrastructurePlugin):
         ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
         ("50caaf268b4f3d260d720a1a29c5fe21", "PHP Logo 2"),
         ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.2.11"] = [
+        ("54f426521bf61f2d95c8bfaa13857c51", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("50caaf268b4f3d260d720a1a29c5fe21", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.2.12"] = [
+        ("54f426521bf61f2d95c8bfaa13857c51", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("50caaf268b4f3d260d720a1a29c5fe21", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
     EGG_DB["5.2.13"] = [
         ("54f426521bf61f2d95c8bfaa13857c51", "PHP Credits"),
         ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
         ("50caaf268b4f3d260d720a1a29c5fe21", "PHP Logo 2"),
         ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
     EGG_DB["5.2.14"] = [
-        ("935b67af76c36bd96e59cf6bc158389a", "PHP Credits"),
+        ("54f426521bf61f2d95c8bfaa13857c51", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("50caaf268b4f3d260d720a1a29c5fe21", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.2.15"] = [
+        ("adb361b9255c1e5275e5bd6e2907c5fb", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("50caaf268b4f3d260d720a1a29c5fe21", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.2.16"] = [
+        ("adb361b9255c1e5275e5bd6e2907c5fb", "PHP Credits"),
         ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
         ("50caaf268b4f3d260d720a1a29c5fe21", "PHP Logo 2"),
         ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]

--- a/plugins/infrastructure/php_eggs.py
+++ b/plugins/infrastructure/php_eggs.py
@@ -212,6 +212,21 @@ class php_eggs(InfrastructurePlugin):
         ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
         ("4b2c92409cf0bcf465d199e93a15ac3f", "PHP Logo 2"),
         ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
+    EGG_DB["4.4.1"] = [
+        ("55bc081f2d460b8e6eb326a953c0e71e", "PHP Credits"),
+        ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
+        ("4b2c92409cf0bcf465d199e93a15ac3f", "PHP Logo 2"),
+        ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
+    EGG_DB["4.4.2"] = [
+        ("bed7ceff09e9666d96fdf3518af78e0e", "PHP Credits"),
+        ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
+        ("4b2c92409cf0bcf465d199e93a15ac3f", "PHP Logo 2"),
+        ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
+    EGG_DB["4.4.3"] = [
+        ("bed7ceff09e9666d96fdf3518af78e0e", "PHP Credits"),
+        ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
+        ("4b2c92409cf0bcf465d199e93a15ac3f", "PHP Logo 2"),
+        ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
     EGG_DB["4.4.4"] = [
         ("bed7ceff09e9666d96fdf3518af78e0e", "PHP Credits"),
         ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
@@ -222,8 +237,28 @@ class php_eggs(InfrastructurePlugin):
         ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
         ("4b2c92409cf0bcf465d199e93a15ac3f", "PHP Logo 2"),
         ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
+    EGG_DB["4.4.5"] = [
+        ("692a87ca2c51523c17f597253653c777", "PHP Credits"),
+        ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
+        ("4b2c92409cf0bcf465d199e93a15ac3f", "PHP Logo 2"),
+        ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
+    EGG_DB["4.4.6"] = [
+        ("692a87ca2c51523c17f597253653c777", "PHP Credits"),
+        ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
+        ("4b2c92409cf0bcf465d199e93a15ac3f", "PHP Logo 2"),
+        ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
+    EGG_DB["4.4.7"] = [
+        ("692a87ca2c51523c17f597253653c777", "PHP Credits"),
+        ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
+        ("4b2c92409cf0bcf465d199e93a15ac3f", "PHP Logo 2"),
+        ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
     EGG_DB["4.4.7"] = [
         ("72b7ad604fe1362f1e8bf4f6d80d4edc", "PHP Credits"),
+        ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
+        ("4b2c92409cf0bcf465d199e93a15ac3f", "PHP Logo 2"),
+        ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
+    EGG_DB["4.4.8"] = [
+        ("50ac182f03fc56a719a41fc1786d937d", "PHP Credits"),
         ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
         ("4b2c92409cf0bcf465d199e93a15ac3f", "PHP Logo 2"),
         ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]

--- a/plugins/infrastructure/php_eggs.py
+++ b/plugins/infrastructure/php_eggs.py
@@ -49,6 +49,41 @@ class php_eggs(InfrastructurePlugin):
     # This is a list of hashes and description of the egg for every PHP version.
     #
     EGG_DB = {}
+    EGG_DB["4.0.0"] = [
+        ("7c75d38f7b26b7cc13ed1d7bbedd0bb8", "PHP Credits"),
+        ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
+        ("85be3b4be7bfe839cbb3b4f2d30ff983", "PHP Logo 2"),
+        ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
+    EGG_DB["4.0.1"] = [
+        ("31e2dd536176af3f7f142c18eef1aa4e", "PHP Credits"),
+        ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
+        ("85be3b4be7bfe839cbb3b4f2d30ff983", "PHP Logo 2"),
+        ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
+    EGG_DB["4.0.2"] = [
+        ("34591272f6dd5cf9953b65dfdb390259", "PHP Credits"),
+        ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
+        ("85be3b4be7bfe839cbb3b4f2d30ff983", "PHP Logo 2"),
+        ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
+    EGG_DB["4.0.3pl1"] = [
+        ("34591272f6dd5cf9953b65dfdb390259", "PHP Credits"),
+        ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
+        ("85be3b4be7bfe839cbb3b4f2d30ff983", "PHP Logo 2"),
+        ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
+    EGG_DB["4.0.4pl1"] = [
+        ("bee683d024c0065a6e7ae57458416f60", "PHP Credits"),
+        ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
+        ("85be3b4be7bfe839cbb3b4f2d30ff983", "PHP Logo 2"),
+        ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
+    EGG_DB["4.0.5"] = [
+        ("34040cf89a0574e7de5c643da6d9eab8", "PHP Credits"),
+        ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
+        ("85be3b4be7bfe839cbb3b4f2d30ff983", "PHP Logo 2"),
+        ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
+    EGG_DB["4.0.6"] = [
+        ("5bd3e883d03543baf7f39749d526c5a4", "PHP Credits"),
+        ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
+        ("85be3b4be7bfe839cbb3b4f2d30ff983", "PHP Logo 2"),
+        ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
     EGG_DB["4.1.2"] = [
         ("744aecef04f9ed1bc39ae773c40017d1", "PHP Credits"),
         ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),

--- a/plugins/infrastructure/php_eggs.py
+++ b/plugins/infrastructure/php_eggs.py
@@ -56,8 +56,9 @@ class php_eggs(InfrastructurePlugin):
     # PHP versions 5.1.0 - 5.1.6
     # PHP versions 5.2.0 - 5.2.17
     # PHP versions 5.3.0 - 5.3.26 (still in progress)
-    # PHP versions 5.4.0 - 5.4.15 (still in progress)
-    # PHP versions 5.5.x has no PHP-Eggs
+    # PHP versions 5.4.0 - 5.4.16 (still in progress)
+    # Remark: PHP versions 5.5.x has no PHP-Eggs.
+    # Remark: PHP Logo 2 is not always available. 
     
     
     EGG_DB = {}
@@ -658,13 +659,88 @@ class php_eggs(InfrastructurePlugin):
         ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
         ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
         ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.4.0"] = [
+        ("85da0a620fabe694dab1d55cbf1e24c3", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.4.1"] = [
+        ("85da0a620fabe694dab1d55cbf1e24c3", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.4.2"] = [
+        ("85da0a620fabe694dab1d55cbf1e24c3", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.4.3"] = [
+        ("85da0a620fabe694dab1d55cbf1e24c3", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.4.4"] = [
+        ("85da0a620fabe694dab1d55cbf1e24c3", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.4.5"] = [
+        ("85da0a620fabe694dab1d55cbf1e24c3", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.4.6"] = [
+        ("85da0a620fabe694dab1d55cbf1e24c3", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
     EGG_DB["5.4.7"] = [
+        ("85da0a620fabe694dab1d55cbf1e24c3", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.4.8"] = [
+        ("85da0a620fabe694dab1d55cbf1e24c3", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.4.9"] = [
+        ("85da0a620fabe694dab1d55cbf1e24c3", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.4.10"] = [
+        ("85da0a620fabe694dab1d55cbf1e24c3", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.4.11"] = [
+        ("85da0a620fabe694dab1d55cbf1e24c3", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.4.12"] = [
+        ("85da0a620fabe694dab1d55cbf1e24c3", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.4.13"] = [
         ("85da0a620fabe694dab1d55cbf1e24c3", "PHP Credits"),
         ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
         ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
         ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
     EGG_DB["5.4.14"] = [
         ("85da0a620fabe694dab1d55cbf1e24c3", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.4.15"] = [
+        ("ebf6d0333d67af5f80077438c45c8eaa", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.4.16"] = [
+        ("ebf6d0333d67af5f80077438c45c8eaa", "PHP Credits"),
         ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
         ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
         ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]

--- a/plugins/infrastructure/php_eggs.py
+++ b/plugins/infrastructure/php_eggs.py
@@ -124,8 +124,57 @@ class php_eggs(InfrastructurePlugin):
         ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
         ("85be3b4be7bfe839cbb3b4f2d30ff983", "PHP Logo 2"),
         ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
+    EGG_DB["4.3.0"] = [
+        ("1e04761e912831dd29b7a98785e7ac61", "PHP Credits"),
+        ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
+        ("a57bd73e27be03a62dd6b3e1b537a72c", "PHP Logo 2"),
+        ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
+    EGG_DB["4.3.1"] = [
+        ("1e04761e912831dd29b7a98785e7ac61", "PHP Credits"),
+        ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
+        ("a57bd73e27be03a62dd6b3e1b537a72c", "PHP Logo 2"),
+        ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
+    EGG_DB["4.3.2"] = [
+        ("22d03c3c0a9cff6d760a4ba63909faea", "PHP Credits"),
+        ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
+        ("a57bd73e27be03a62dd6b3e1b537a72c", "PHP Logo 2"),
+        ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
+    EGG_DB["4.3.3"] = [
+        ("8a4a61f60025b43f11a7c998f02b1902", "PHP Credits"),
+        ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
+        ("a57bd73e27be03a62dd6b3e1b537a72c", "PHP Logo 2"),
+        ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
+    EGG_DB["4.3.4"] = [
+        ("8a4a61f60025b43f11a7c998f02b1902", "PHP Credits"),
+        ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
+        ("a57bd73e27be03a62dd6b3e1b537a72c", "PHP Logo 2"),
+        ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
+    EGG_DB["4.3.5"] = [
+        ("8a4a61f60025b43f11a7c998f02b1902", "PHP Credits"),
+        ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
+        ("a57bd73e27be03a62dd6b3e1b537a72c", "PHP Logo 2"),
+        ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
+    EGG_DB["4.3.6"] = [
+        ("913ec921cf487109084a518f91e70859", "PHP Credits"),
+        ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
+        ("a57bd73e27be03a62dd6b3e1b537a72c", "PHP Logo 2"),
+        ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
+    EGG_DB["4.3.7"] = [
+        ("913ec921cf487109084a518f91e70859", "PHP Credits"),
+        ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
+        ("a57bd73e27be03a62dd6b3e1b537a72c", "PHP Logo 2"),
+        ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
+    EGG_DB["4.3.8"] = [
+        ("913ec921cf487109084a518f91e70859", "PHP Credits"),
+        ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
+        ("a57bd73e27be03a62dd6b3e1b537a72c", "PHP Logo 2"),
+        ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
+    EGG_DB["4.3.9"] = [
+        ("913ec921cf487109084a518f91e70859", "PHP Credits"),
+        ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
+        ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
     EGG_DB["4.3.10"] = [
-        ("1e8fe4ae1bf06be222c1643d32015f0c", "PHP Credits"),
+        ("8fbf48d5a2a64065fc26db3e890b9871", "PHP Credits"),
         ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
         ("a57bd73e27be03a62dd6b3e1b537a72c", "PHP Logo 2"),
         ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
@@ -135,17 +184,12 @@ class php_eggs(InfrastructurePlugin):
         ("4b2c92409cf0bcf465d199e93a15ac3f", "PHP Logo 2"),
         ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
     EGG_DB["4.3.11"] = [
-        ("1e8fe4ae1bf06be222c1643d32015f0c", "PHP Credits"),
+        ("8fbf48d5a2a64065fc26db3e890b9871", "PHP Credits"),
         ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
-        ("a8ad323e837fa00771eda6b709f40e37", "PHP Logo 2"),
-        ("a8ad323e837fa00771eda6b709f40e37", "Zend Logo")]
+        ("4b2c92409cf0bcf465d199e93a15ac3f", "PHP Logo 2"),
+        ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
     EGG_DB["4.3.2"] = [
         ("8a8b4a419103078d82707cf68226a482", "PHP Credits"),
-        ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
-        ("a57bd73e27be03a62dd6b3e1b537a72c", "PHP Logo 2"),
-        ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
-    EGG_DB["4.3.8"] = [
-        ("96714a0fbe23b5c07c8be343adb1ba90", "PHP Credits"),
         ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
         ("a57bd73e27be03a62dd6b3e1b537a72c", "PHP Logo 2"),
         ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]

--- a/plugins/infrastructure/php_eggs.py
+++ b/plugins/infrastructure/php_eggs.py
@@ -47,7 +47,19 @@ class php_eggs(InfrastructurePlugin):
 
     #
     # This is a list of hashes and description of the egg for every PHP version.
-    #
+    # PHP versions 4.0.0 - 4.0.6
+    # PHP versions 4.1.0 - 4.1.3
+    # PHP versions 4.2.0 - 4.2.3
+    # PHP versions 4.3.0 - 4.3.11
+    # PHP versions 4.4.0 - 4.4.9
+    # PHP versions 5.0.0 - 5.0.5
+    # PHP versions 5.1.0 - 5.1.6
+    # PHP versions 5.2.0 - 5.2.17
+    # PHP versions 5.3.0 - 5.3.26 (still in progress)
+    # PHP versions 5.4.0 - 5.4.15 (still in progress)
+    # PHP versions 5.5.x has no PHP-Eggs
+    
+    
     EGG_DB = {}
     EGG_DB["4.0.0"] = [
         ("7c75d38f7b26b7cc13ed1d7bbedd0bb8", "PHP Credits"),
@@ -501,6 +513,16 @@ class php_eggs(InfrastructurePlugin):
         ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
         ("50caaf268b4f3d260d720a1a29c5fe21", "PHP Logo 2"),
         ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.3.0"] = [
+        ("db23b07a9b426d0d033565b878b1e384", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.3.1"] = [
+        ("a4c057b11fa0fba98c8e26cd7bb762a8", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
     EGG_DB["5.3.2"] = [
         ("a4c057b11fa0fba98c8e26cd7bb762a8", "PHP Credits"),
         ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
@@ -508,6 +530,11 @@ class php_eggs(InfrastructurePlugin):
         ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
     EGG_DB["5.3.3"] = [
         ("b34501471d51cebafacdd45bf2cd545d", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.3.4"] = [
+        ("e3b18899d0ffdf8322ed18d7bce3c9a0", "PHP Credits"),
         ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
         ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
         ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
@@ -521,17 +548,82 @@ class php_eggs(InfrastructurePlugin):
         ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
         ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
         ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.3.7"] = [
+        ("f1f1f60ac0dcd700a1ad30aa81175d34", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.3.8"] = [
+        ("f1f1f60ac0dcd700a1ad30aa81175d34", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.3.9"] = [
+        ("23f183b78eb4e3ba8b3df13f0a15e5de", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
     EGG_DB["5.3.10"] = [
         ("23f183b78eb4e3ba8b3df13f0a15e5de", "PHP Credits"),
         ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
         ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
         ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.3.11"] = [
+        ("23f183b78eb4e3ba8b3df13f0a15e5de", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.3.12"] = [
+        ("23f183b78eb4e3ba8b3df13f0a15e5de", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.3.13"] = [
+        ("23f183b78eb4e3ba8b3df13f0a15e5de", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.3.14"] = [
+        ("23f183b78eb4e3ba8b3df13f0a15e5de", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.3.15"] = [
+        ("23f183b78eb4e3ba8b3df13f0a15e5de", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.3.16"] = [
+        ("23f183b78eb4e3ba8b3df13f0a15e5de", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.3.17"] = [
+        ("23f183b78eb4e3ba8b3df13f0a15e5de", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.3.18"] = [
+        ("23f183b78eb4e3ba8b3df13f0a15e5de", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
     EGG_DB["5.3.19"] = [
-        ("ca62f8b5c1be8124d6f388dc5e380fee", "PHP Credits"),
+        ("23f183b78eb4e3ba8b3df13f0a15e5de", "PHP Credits"),
         ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
         ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
         ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
     EGG_DB["5.3.20"] = [
+        ("23f183b78eb4e3ba8b3df13f0a15e5de", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.3.21"] = [
+        ("23f183b78eb4e3ba8b3df13f0a15e5de", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.3.22"] = [
         ("23f183b78eb4e3ba8b3df13f0a15e5de", "PHP Credits"),
         ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
         ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
@@ -543,6 +635,11 @@ class php_eggs(InfrastructurePlugin):
         ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
     EGG_DB["5.3.23"] = [
         ("5e8e6736635920a0a97ba79d69c55b30", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.3.23"] = [
+        ("23f183b78eb4e3ba8b3df13f0a15e5de", "PHP Credits"),
         ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
         ("fb3bbd9ccc4b3d9e0b3be89c5ff98a14", "PHP Logo 2"),
         ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]

--- a/plugins/infrastructure/php_eggs.py
+++ b/plugins/infrastructure/php_eggs.py
@@ -496,8 +496,9 @@ class php_eggs(InfrastructurePlugin):
         '''
         return '''
         This plugin tries to find the documented easter eggs that exist in PHP
-        and identify the remote PHP version using the easter egg content. The
-        easter eggs that this plugin verifies are:
+        and identifies the remote PHP version using the easter egg content.
+        Known PHP easter eggs are visible in versions 4.0 - 5.4.
+        The easter eggs that this plugin verifies are:
 
         PHP Credits, Logo, Zend Logo, PHP Logo 2:
             - http://php.net/?=PHPB8B5F2A0-3C92-11d3-A3A9-4C7B08C10000

--- a/plugins/infrastructure/php_eggs.py
+++ b/plugins/infrastructure/php_eggs.py
@@ -84,13 +84,43 @@ class php_eggs(InfrastructurePlugin):
         ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
         ("85be3b4be7bfe839cbb3b4f2d30ff983", "PHP Logo 2"),
         ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
+    EGG_DB["4.1.0"] = [
+        ("744aecef04f9ed1bc39ae773c40017d1", "PHP Credits"),
+        ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
+        ("85be3b4be7bfe839cbb3b4f2d30ff983", "PHP Logo 2"),
+        ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
+    EGG_DB["4.1.1"] = [
+        ("744aecef04f9ed1bc39ae773c40017d1", "PHP Credits"),
+        ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
+        ("85be3b4be7bfe839cbb3b4f2d30ff983", "PHP Logo 2"),
+        ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
     EGG_DB["4.1.2"] = [
         ("744aecef04f9ed1bc39ae773c40017d1", "PHP Credits"),
         ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
         ("85be3b4be7bfe839cbb3b4f2d30ff983", "PHP Logo 2"),
         ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
+    EGG_DB["4.1.3"] = [
+        ("744aecef04f9ed1bc39ae773c40017d1", "PHP Credits"),
+        ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
+        ("85be3b4be7bfe839cbb3b4f2d30ff983", "PHP Logo 2"),
+        ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
+    EGG_DB["4.2.0"] = [
+        ("8bc001f58bf6c17a67e1ca288cb459cc", "PHP Credits"),
+        ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
+        ("85be3b4be7bfe839cbb3b4f2d30ff983", "PHP Logo 2"),
+        ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
+    EGG_DB["4.2.1"] = [
+        ("8bc001f58bf6c17a67e1ca288cb459cc", "PHP Credits"),
+        ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
+        ("85be3b4be7bfe839cbb3b4f2d30ff983", "PHP Logo 2"),
+        ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
     EGG_DB["4.2.2"] = [
-        ("758ccaa9094cdeedcfc60017e768137e", "PHP Credits"),
+        ("8bc001f58bf6c17a67e1ca288cb459cc", "PHP Credits"),
+        ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
+        ("85be3b4be7bfe839cbb3b4f2d30ff983", "PHP Logo 2"),
+        ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
+    EGG_DB["4.2.3"] = [
+        ("3422eded2fcceb3c89cabb5156b5d4e2", "PHP Credits"),
         ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
         ("85be3b4be7bfe839cbb3b4f2d30ff983", "PHP Logo 2"),
         ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]

--- a/plugins/infrastructure/php_eggs.py
+++ b/plugins/infrastructure/php_eggs.py
@@ -317,15 +317,51 @@ class php_eggs(InfrastructurePlugin):
         ("8ac5a686135b923664f64fe718ea55cd", "PHP Logo"),
         ("4b2c92409cf0bcf465d199e93a15ac3f", "PHP Logo 2"),
         ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.1.0RC1"] = [
+        ("2673a94df41739ef8b012c07518b6c6f", "PHP Credits"),
+        ("8ac5a686135b923664f64fe718ea55cd", "PHP Logo"),
+        ("4b2c92409cf0bcf465d199e93a15ac3f", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.1.0"] = [
+        ("5518a02af41478cfc492c930ace45ae5", "PHP Credits"),
+        ("8ac5a686135b923664f64fe718ea55cd", "PHP Logo"),
+        ("4b2c92409cf0bcf465d199e93a15ac3f", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
     EGG_DB["5.1.1"] = [
         ("5518a02af41478cfc492c930ace45ae5", "PHP Credits"),
         ("8ac5a686135b923664f64fe718ea55cd", "PHP Logo"),
+        ("4b2c92409cf0bcf465d199e93a15ac3f", "PHP Logo 2"),
         ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
-    EGG_DB['5.1.2'] = [
-        ('b83433fb99d0bef643709364f059a44a', 'PHP Credits'),
-        ('8ac5a686135b923664f64fe718ea55cd', 'PHP Logo'),
-        ('4b2c92409cf0bcf465d199e93a15ac3f', 'PHP Logo 2'),
-        ('7675f1d01c927f9e6a4752cf182345a2', 'Zend Logo')]
+    EGG_DB["5.1.2"] = [
+        ("6cb0a5ba2d88f9d6c5c9e144dd5941a6", "PHP Credits"),
+        ("8ac5a686135b923664f64fe718ea55cd", "PHP Logo"),
+        ("4b2c92409cf0bcf465d199e93a15ac3f", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.1.2"] = [
+        ("b83433fb99d0bef643709364f059a44a", "PHP Credits"),
+        ("8ac5a686135b923664f64fe718ea55cd", "PHP Logo"),
+        ("4b2c92409cf0bcf465d199e93a15ac3f", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.1.3"] = [
+        ("82fa2d6aa15f971f7dadefe4f2ac20e3", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("50caaf268b4f3d260d720a1a29c5fe21", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.1.4"] = [
+        ("82fa2d6aa15f971f7dadefe4f2ac20e3", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("50caaf268b4f3d260d720a1a29c5fe21", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.1.5"] = [
+        ("82fa2d6aa15f971f7dadefe4f2ac20e3", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("50caaf268b4f3d260d720a1a29c5fe21", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.1.5"] = [
+        ("82fa2d6aa15f971f7dadefe4f2ac20e3", "PHP Credits"),
+        ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),
+        ("50caaf268b4f3d260d720a1a29c5fe21", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
     EGG_DB["5.1.6"] = [
         ("4b689316409eb09b155852e00657a0ae", "PHP Credits"),
         ("c48b07899917dfb5d591032007041ae3", "PHP Logo"),

--- a/plugins/infrastructure/php_eggs.py
+++ b/plugins/infrastructure/php_eggs.py
@@ -128,10 +128,45 @@ class php_eggs(InfrastructurePlugin):
         ("11b9cfe306004fce599a1f8180b61266", "PHP Logo"),
         ("4b2c92409cf0bcf465d199e93a15ac3f", "PHP Logo 2"),
         ("da2dae87b166b7709dbd4061375b74cb", "Zend Logo")]
-    EGG_DB["5.0.3"] = [
-        ("def61a12c3b0a533146810403d325451", "PHP Credits"),
+    EGG_DB["5.0.0RC1"] = [
+        ("314e92ddb1a8abc0781ab87d5b66e960", "PHP Credits"),
         ("8ac5a686135b923664f64fe718ea55cd", "PHP Logo"),
         ("37e194b799d4aaff10e39c4e3b2679a2", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.0.0RC2"] = [
+        ("e54dbf41d985bfbfa316dba207ad6bce", "PHP Credits"),
+        ("8ac5a686135b923664f64fe718ea55cd", "PHP Logo"),
+        ("37e194b799d4aaff10e39c4e3b2679a2", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.0.0RC3"] = [
+        ("e54dbf41d985bfbfa316dba207ad6bce", "PHP Credits"),
+        ("8ac5a686135b923664f64fe718ea55cd", "PHP Logo"),
+        ("37e194b799d4aaff10e39c4e3b2679a2", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.0.0"] = [
+        ("e54dbf41d985bfbfa316dba207ad6bce", "PHP Credits"),
+        ("8ac5a686135b923664f64fe718ea55cd", "PHP Logo"),
+        ("37e194b799d4aaff10e39c4e3b2679a2", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.0.1"] = [
+        ("3c31e4674f42a49108b5300f8e73be26", "PHP Credits"),
+        ("8ac5a686135b923664f64fe718ea55cd", "PHP Logo"),
+        ("37e194b799d4aaff10e39c4e3b2679a2", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.0.2"] = [
+        ("3c31e4674f42a49108b5300f8e73be26", "PHP Credits"),
+        ("8ac5a686135b923664f64fe718ea55cd", "PHP Logo"),
+        ("37e194b799d4aaff10e39c4e3b2679a2", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.0.3"] = [
+        ("3c31e4674f42a49108b5300f8e73be26", "PHP Credits"),
+        ("8ac5a686135b923664f64fe718ea55cd", "PHP Logo"),
+        ("37e194b799d4aaff10e39c4e3b2679a2", "PHP Logo 2"),
+        ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
+    EGG_DB["5.0.4"] = [
+        ("3c31e4674f42a49108b5300f8e73be26", "PHP Credits"),
+        ("8ac5a686135b923664f64fe718ea55cd", "PHP Logo"),
+        ("4b2c92409cf0bcf465d199e93a15ac3f", "PHP Logo 2"),
         ("7675f1d01c927f9e6a4752cf182345a2", "Zend Logo")]
     EGG_DB["5.0.5"] = [
         ("6be3565cdd38e717e4eb96868d9be141", "PHP Credits"),


### PR DESCRIPTION
Changed description of plugin.
PHP Eggs are no longer "visible" in future PHP version 5.5 and later.
