### PR TITLE
Avoiding false positives

### DIFF
--- a/plugins/audit/xss.py
+++ b/plugins/audit/xss.py
@@ -45,8 +45,8 @@ class xss(AuditPlugin):
     PAYLOADS = [
                 'RANDOMIZE</->',
                 'RANDOMIZE/*',
-                'RANDOMIZE"',
-                "RANDOMIZE'",
+                'RANDOMIZE"RANDOMIZE',
+                "RANDOMIZE'RANDOMIZE",
                 "RANDOMIZE`",
                 "RANDOMIZE ="
                 ]


### PR DESCRIPTION
We're getting false positives due to the position of the `"` and `'` characters
