### PR TITLE
Dependency check not imports traceroute from scapy.all to check for bug 341

### DIFF
--- a/core/controllers/dependency_check/dependency_check.py
+++ b/core/controllers/dependency_check/dependency_check.py
@@ -76,6 +76,26 @@ def dependency_check(pip_packages=PIP_PACKAGES, system_packages=SYSTEM_PACKAGES,
 
     # All installed?
     if not failed_deps and not os_packages:
+        #check if scapy is correctly installed on OSX
+        try:
+            from scapy.all import traceroute
+        except OSError, ose:
+            if "Device not configured" in str(ose):
+                print 'Tried to import traceroute from scapy.all. There was an OSError including the message "Device not configured"' 
+                print "This is a bug in the scapy library and happens on OSX with MacPorts i.e. when Virtualbox is installed"
+                print "Please apply the following fix (example for python 2.7):"
+                print "Open the file /opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/scapy/arch/unix.py"
+                print 'Change line 34 from: f=os.popen("netstat -rn") # -f inet'
+                print '                 to: f=os.popen("netstat -rn|grep -v vboxnet") # -f inet'
+                print 'Original bug report:'
+                print 'http://bb.secdev.org/scapy/issue/418/scapy-error-in-mac-osx-leopard'
+                print ''
+                if exit_on_failure:
+                    sys.exit(1)
+                else:
+                    return True
+            raise ose
+        
         # False means: do not exit()
         return False
 

--- a/core/controllers/dependency_check/platforms/mac.py
+++ b/core/controllers/dependency_check/platforms/mac.py
@@ -105,3 +105,23 @@ def after_hook():
           ' switch to the Mac ports Python by using the following command:\n'\
           '    sudo port select python python27\n\n'
     print msg % sys.executable
+    
+    #check if scapy is correctly installed on OSX
+    try:
+        from scapy.all import traceroute
+    except OSError, ose:
+        if "Device not configured" in str(ose):
+            msg = 'Tried to import traceroute from scapy.all. '\
+                  'There was an OSError including the message "Device not configured".'\
+                  'This is a bug in the scapy library and happens on OSX with MacPorts'\
+                  ' i.e. when Virtualbox is installed.\n Please apply the following fix '\
+                  '(example for python 2.7):\nOpen the file /opt/local/Library/Framewo'\
+                  'rks/Python.framework/Versions/2.7/lib/python2.7/site-packages/scapy'\
+                  '/arch/unix.py\n'\
+                  'Change line 34 from: f=os.popen("netstat -rn") # -f inet\n'\
+                  '                 to: f=os.popen("netstat -rn|grep -v vboxnet") # -f inet'\
+                  'Original bug report:\n'\
+                  'http://bb.secdev.org/scapy/issue/418/scapy-error-in-mac-osx-leopard\n\n'\
+            print msg % sys.executable
+        raise ose
+    


### PR DESCRIPTION
fixes scapy related bug 341 on Mac OSX with MacPorts and Virtualbox.

https://github.com/andresriancho/w3af/issues/341#issuecomment-22103644
