### PR TITLE
Fix #664: Pip should install GitPython 0.2.x or higher.

### DIFF
--- a/core/controllers/dependency_check/platforms/fedora.py
+++ b/core/controllers/dependency_check/platforms/fedora.py
@@ -41,7 +41,7 @@ PHPLY_GIT = 'git+git://github.com/ramen/phply.git#egg=phply'
 
 PIP_PACKAGES = [PIPDependency('clamd', 'clamd'),
                 PIPDependency('github', 'PyGithub'),
-                PIPDependency('git.util', 'GitPython', SYSTEM_PACKAGES['GIT']),
+                PIPDependency('git.util', '"GitPython>=0.2.0-beta1"', SYSTEM_PACKAGES['GIT']),
                 PIPDependency('pybloomfilter', 'pybloomfiltermmap',
                               SYSTEM_PACKAGES['C_BUILD'] + SYSTEM_PACKAGES['SSLDEV']),
                 PIPDependency('esmre', 'esmre'),

--- a/core/controllers/dependency_check/platforms/linux.py
+++ b/core/controllers/dependency_check/platforms/linux.py
@@ -40,7 +40,7 @@ PHPLY_GIT = 'git+git://github.com/ramen/phply.git#egg=phply'
 
 PIP_PACKAGES = [PIPDependency('clamd', 'clamd'),
                 PIPDependency('github', 'PyGithub'),
-                PIPDependency('git.util', 'GitPython', SYSTEM_PACKAGES['GIT']),
+                PIPDependency('git.util', '"GitPython>=0.2.0-beta1"', SYSTEM_PACKAGES['GIT']),
                 PIPDependency('pybloomfilter', 'pybloomfiltermmap',
                               SYSTEM_PACKAGES['C_BUILD']),
                 PIPDependency('esmre', 'esmre'),

--- a/core/controllers/dependency_check/platforms/mac.py
+++ b/core/controllers/dependency_check/platforms/mac.py
@@ -45,7 +45,7 @@ PHPLY_GIT = 'git+git://github.com/ramen/phply.git#egg=phply'
 
 PIP_PACKAGES = [PIPDependency('clamd', 'clamd'),
                 PIPDependency('github', 'PyGithub'),
-                PIPDependency('git.util', 'GitPython', SYSTEM_PACKAGES['GIT']),
+                PIPDependency('git.util', '"GitPython>=0.2.0-beta1"', SYSTEM_PACKAGES['GIT']),
                 PIPDependency('pybloomfilter', 'pybloomfiltermmap',
                               SYSTEM_PACKAGES['C_BUILD']),
                 PIPDependency('esmre', 'esmre'),

--- a/core/controllers/dependency_check/platforms/openbsd.py
+++ b/core/controllers/dependency_check/platforms/openbsd.py
@@ -43,7 +43,7 @@ PHPLY_GIT = 'git+git://github.com/ramen/phply.git#egg=phply'
 
 PIP_PACKAGES = [PIPDependency('clamd', 'clamd'),
                 PIPDependency('github', 'PyGithub'),
-                PIPDependency('git.util', 'GitPython', SYSTEM_PACKAGES['GIT']),
+                PIPDependency('git.util', '"GitPython>=0.2.0-beta1"', SYSTEM_PACKAGES['GIT']),
                 PIPDependency('pybloomfilter', 'pybloomfiltermmap',
                               SYSTEM_PACKAGES['C_BUILD']),
                 PIPDependency('esmre', 'esmre'),

--- a/core/controllers/dependency_check/platforms/suse.py
+++ b/core/controllers/dependency_check/platforms/suse.py
@@ -42,7 +42,7 @@ PHPLY_GIT = 'git+git://github.com/ramen/phply.git#egg=phply'
 
 PIP_PACKAGES = [PIPDependency('clamd', 'clamd'),
                 PIPDependency('github', 'PyGithub'),
-                PIPDependency('git.util', 'GitPython', SYSTEM_PACKAGES['GIT']),
+                PIPDependency('git.util', '"GitPython>=0.2.0-beta1"', SYSTEM_PACKAGES['GIT']),
                 PIPDependency('pybloomfilter', 'pybloomfiltermmap',
                               SYSTEM_PACKAGES['C_BUILD']),
                 PIPDependency('esmre', 'esmre'),


### PR DESCRIPTION
By default, pip installs GitPython version 0.1.7

% pip install GitPython
Downloading/unpacking GitPython
  Downloading GitPython-0.1.7.tar.gz
  Running setup.py egg_info for package GitPython

Installing collected packages: GitPython
  Running setup.py install for GitPython

Successfully installed GitPython
Cleaning up...

Which among other things causes the "util" issue, doesn't have RemoteProgress etc,.

Thus, version 0.2.0-beta1 of GitPython should be specified as the lowest requirement for Pip. Double quotes are specified as the > sign is a Bash special character.
