### PR TITLE
Changed the requirements for CentOS

### DIFF
--- a/w3af/core/controllers/dependency_check/platforms/centos.py
+++ b/w3af/core/controllers/dependency_check/platforms/centos.py
@@ -28,7 +28,7 @@ PKG_MANAGER_CMD = 'sudo yum install'
 SYSTEM_PACKAGES = {
                    'PIP': ['python-pip'],
                    'C_BUILD': ['python-devel', 'python-setuptools',
-                               'libsqlite3x-devel', 'gcc-c++', 'gcc', 'make'],
+                               'sqlite-devel', 'gcc-c++', 'gcc', 'make'],
                    'GIT': ['git'],
                    'XML': ['libxml2-devel', 'libxslt-devel'],
                    'SSL': ['pyOpenSSL', 'openssl-devel', 'libcom_err-devel',


### PR DESCRIPTION
Changed the requirements for CentOS.
From: libsqlite3x-devel
To: sqlite-devel
w3af_console is now able to start on CenOS 6.5, I have not tested this on CentOS 5.x yet.
