### PR TITLE
Skip pragma cache warning for 30x responses

### DIFF
--- a/w3af/plugins/grep/cache_control.py
+++ b/w3af/plugins/grep/cache_control.py
@@ -57,6 +57,10 @@ class cache_control(GrepPlugin):
 
         elif response.get_url().get_protocol() == 'http':
             return
+
+        elif response.get_code() > 300\
+        and response.get_code() < 310:
+            return
         
         elif response.body == '':
             return


### PR DESCRIPTION
As the description implies. I tested this against my application and no longer received the warnings for 30x responses, only the 404 responses, which are OK as we discussed on the mailing list.
