### PR TITLE
Remove duplicates on methods discovered by allowed_methods.py plugin

### DIFF
--- a/w3af/plugins/infrastructure/allowed_methods.py
+++ b/w3af/plugins/infrastructure/allowed_methods.py
@@ -100,6 +100,12 @@ class allowed_methods(InfrastructurePlugin):
         allowed_bf, id_bf = self._identify_with_bruteforce(url)
         
         allowed_methods = allowed_options + allowed_bf
+        # If a method was found by both, bf and options, it is duplicated in 
+        # the list. Remove dups
+        allowed_methods = list(set(allowed_methods))
+        # There are no duplicate requests.
+        # Even if a method was discovered with both, bf and options, we 
+        # furthermore want to see both requests
         id_list = id_options + id_bf
         
         # Added this to make the output a little bit more readable.


### PR DESCRIPTION
Example allowed_methods.py output before this change:
The URL "http://w3/" has the following enabled HTTP methods: CONNECT, GET, GET,
HEAD, HEAD, OPTIONS, OPTIONS, POST, POST. This information was found in the
requests with ids 32, 39, 47, 52, 55 and 71.

Example allowed_methods.py output after this change:
The URL "http://w3/" has the following enabled HTTP methods: CONNECT, GET, HEAD,
OPTIONS, POST. This information was found in the requests with ids 32, 39, 47,
52, 55 and 71.

Note that duplicate methods are removed and request ID list is kept unchanged.
We want to keep all IDs to see related requests no matter what the discovery
method was (bruteforce or an OPTIONS request)
