### PR TITLE
fix issue 3688

### DIFF
--- a/w3af/plugins/crawl/wordpress_enumerate_users.py
+++ b/w3af/plugins/crawl/wordpress_enumerate_users.py
@@ -81,7 +81,7 @@ class wordpress_enumerate_users(CrawlPlugin):
             uid += 1
             gap += 1
 
-            domain_path.querystring = {u'author': u'%s' % uid}
+            domain_path.querystring = [(u'author', [u'%s' % uid])]
             wp_author_url = domain_path
             response_author = self._uri_opener.GET(wp_author_url, cache=True)
 


### PR DESCRIPTION
https://github.com/andresriancho/w3af/issues/3688

w3af/core/data/dc/generic/kv_container.py explains that expected init_val format
is [(u"b", [u"2", u"3"])] instead of a dict

Example wordpress_enumerate_users.py output before this change:
An exception was found while running crawl.wordpress_enumerate_users on "Method:
GET | http://domain/path/foo/". The exception was: "Undefined order, cannot get
items from dict" at kv_container.py:**init**():55. The scan will continue but
some vulnerabilities might not be identified.

Example wordpress_enumerate_users.py output after this change:
WordPress user "admin" found during username enumeration. This information was
found in the request with id 33.
WordPress user "user" found during username enumeration. This information was
found in the request with id 34.
