### PR TITLE
fix cookie/url order in w3af/plugins/grep/analyze_cookies.py output logs

### DIFF
--- a/w3af/plugins/grep/analyze_cookies.py
+++ b/w3af/plugins/grep/analyze_cookies.py
@@ -376,7 +376,7 @@ class analyze_cookies(GrepPlugin):
 
         tmp = list(set([(c['cookie-string'], c.get_url()) for c in cookies]))
         res_dict, item_idx = group_by_min_key(tmp)
-        if not item_idx:
+        if item_idx:
             # Grouped by URLs
             msg = 'The URL: "%s" sent these cookies:'
         else:


### PR DESCRIPTION
This is a fix for fixing w3af/plugins/grep/analyze_cookies.py output logs.
- Before this change

```
[Sat 20 Sep 2014 01:02:19 PM IST] The URL: "session=.eJyrVipILC4uzy9KUbKCMw2VdJRKi1OL8hJzU4HCMKahUi0AlpgQsQ.Bv7-Sg.o3DtbQ7jObRiXiLNRLMNNYyaDao; HttpOnly; Path=/" sent these cookies:
- http://localhost:5000/login
```
- After this change

```
[Sat 20 Sep 2014 01:14:08 PM IST] The cookie: "session=.eJyrVipILC4uzy9KUbKCMw2VdJRKi1OL8hJzU4HCMKahUi0AlpgQsQ.Bv8BDg.Ua3bb3cfweLBx2APn_LODwMV4_k; HttpOnly; Path=/" was sent by these URLs:
- http://localhost:5000/login
```

Note that the issue is _only_ in the output logs of analyze_cookies.py plugin.
The information that appears in Results/KB Browser/analyze_cookies/Cookie info for the same test is totally correct, and, in fact, it is generated in other different function _collect_cookies() while this fix is in end() function.
