### PR TITLE
Missing openssl-devel dependency for Fedora.

### DIFF
--- a/w3af/core/controllers/dependency_check/platforms/fedora.py
+++ b/w3af/core/controllers/dependency_check/platforms/fedora.py
@@ -33,7 +33,7 @@ class Fedora(Platform):
 
     CORE_SYSTEM_PACKAGES = ['python-pip', 'python-devel', 'python-setuptools',
                             'libsqlite3x-devel', 'git', 'libxml2-devel',
-                            'libxslt-devel']
+                            'libxslt-devel', 'openssl-devel']
 
     GUI_SYSTEM_PACKAGES = CORE_SYSTEM_PACKAGES[:]
     GUI_SYSTEM_PACKAGES.extend(['graphviz', 'pygtksourceview', 'pygtk2'])


### PR DESCRIPTION
This caused the `/tmp/w3af_dependency_install.sh` to fail the first time I ran it, as one of the pip installed modules requires openssl-devel to be installed.  (not sure which one.)
