### PR TITLE
Added Ubuntu 14.10

### DIFF
--- a/w3af/core/controllers/dependency_check/platforms/current_platform.py
+++ b/w3af/core/controllers/dependency_check/platforms/current_platform.py
@@ -21,6 +21,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 """
 from .ubuntu1204 import Ubuntu1204
 from .ubuntu1404 import Ubuntu1404
+from .ubuntu1410 import Ubuntu1410
 from .debian76 import Debian76
 from .debian78 import Debian78
 from .centos import CentOS
@@ -33,7 +34,7 @@ from .suse import SuSE
 from .default import DefaultPlatform
 
 KNOWN_PLATFORMS = [Debian76, Ubuntu1204, CentOS65, CentOS, Fedora, Kali, MacOSX,
-                   OpenBSD5, SuSE, Ubuntu1404]
+                   OpenBSD5, SuSE, Ubuntu1404, Ubuntu1410]
 
 
 def get_current_platform(known_platforms=KNOWN_PLATFORMS):

--- a/w3af/core/controllers/dependency_check/platforms/ubuntu1410.py
+++ b/w3af/core/controllers/dependency_check/platforms/ubuntu1410.py
@@ -1,0 +1,33 @@
+"""
+ubuntu1410.py
+
+Copyright 2014 Andres Riancho
+
+This file is part of w3af, http://w3af.org/ .
+
+w3af is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation version 2 of the License.
+
+w3af is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with w3af; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+"""
+import platform
+
+from .ubuntu1204 import Ubuntu1204
+
+
+class Ubuntu1410(Ubuntu1204):
+    SYSTEM_NAME = 'Ubuntu 14.10'
+
+    @staticmethod
+    def is_current_platform():
+        return 'Ubuntu' in platform.dist() and '14.10' in platform.dist()
+


### PR DESCRIPTION
Based on testing of DigitalOcean image added Ubuntu 14.10 platform. Had to add python-psutil to CORE dependency list as this is apparently no longer installed by default (at least by DigitalOcean)
