### PR TITLE
elementaryOS 0.2 'luna' platform addition

### DIFF
--- a/w3af/core/controllers/dependency_check/platforms/current_platform.py
+++ b/w3af/core/controllers/dependency_check/platforms/current_platform.py
@@ -31,10 +31,11 @@ from .kali import Kali
 from .mac import MacOSX
 from .openbsd import OpenBSD5
 from .suse import SuSE
+from .elementaryOS02 import ElementaryOS02
 from .default import DefaultPlatform
 
 KNOWN_PLATFORMS = [Debian76, Ubuntu1204, CentOS65, CentOS, Fedora, Kali, MacOSX,
-                   OpenBSD5, SuSE, Ubuntu1404, Ubuntu1410]
+                   OpenBSD5, SuSE, Ubuntu1404, Ubuntu1410, ElementaryOS02]
 
 
 def get_current_platform(known_platforms=KNOWN_PLATFORMS):

--- a/w3af/core/controllers/dependency_check/platforms/elementaryOS02.py
+++ b/w3af/core/controllers/dependency_check/platforms/elementaryOS02.py
@@ -29,4 +29,4 @@ class ElementaryOS02(Ubuntu1204):
 
     @staticmethod
     def is_current_platform():
-        return 'elementary OS' in platform.dist() and '0.2' in platform.dist()
+        return '"elementary OS"' in platform.dist() and '0.2' in platform.dist()

--- a/w3af/core/controllers/dependency_check/platforms/elementaryOS02.py
+++ b/w3af/core/controllers/dependency_check/platforms/elementaryOS02.py
@@ -25,7 +25,7 @@ from .ubuntu1204 import Ubuntu1204
 
 
 class ElementaryOS02(Ubuntu1204):
-    SYSTEM_NAME = 'elemenataryOS 0.2'
+    SYSTEM_NAME = 'elementaryOS 0.2'
 
     @staticmethod
     def is_current_platform():

--- a/w3af/core/controllers/dependency_check/platforms/elementaryOS02.py
+++ b/w3af/core/controllers/dependency_check/platforms/elementaryOS02.py
@@ -1,0 +1,32 @@
+"""
+elementaryOS02.py
+
+Copyright 2014 Andres Riancho
+
+This file is part of w3af, http://w3af.org/ .
+
+w3af is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation version 2 of the License.
+
+w3af is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with w3af; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+"""
+import platform
+
+from .ubuntu1204 import Ubuntu1204
+
+
+class ElementaryOS02(Ubuntu1204):
+    SYSTEM_NAME = 'elemenataryOS 0.2'
+
+    @staticmethod
+    def is_current_platform():
+        return 'elementary OS' in platform.dist() and '0.2' in platform.dist()


### PR DESCRIPTION
Added elementaryOS 'Luna' as a platform. Tested system via vanilla ISO install on a VirtualBox guest. Worked great. 
