### PR TITLE
Added: missing newlines (\n) in warning messages.

### DIFF
--- a/w3af/core/ui/console/plugins.py
+++ b/w3af/core/ui/console/plugins.py
@@ -193,7 +193,7 @@ class pluginsTypeMenu(menu):
         #
         if self._name == 'output' and 'console' not in enabled and \
                 len(enabled) == 0:
-            msg = "Warning: You disabled the console output plugin. If you"\
+            msg = "\nWarning: You disabled the console output plugin. If you"\
                   " start a new scan, the discovered vulnerabilities won\'t be"\
                   " printed to the console, we advise you to enable at least"\
                   " one output plugin in order to be able to actually see the"\

--- a/w3af/core/ui/console/rootMenu.py
+++ b/w3af/core/ui/console/rootMenu.py
@@ -78,7 +78,7 @@ class rootMenu(menu):
         # Check if the console output plugin is enabled or not, and warn.
         output_plugins = self._w3af.plugins.get_enabled_plugins('output')
         if 'console' not in output_plugins:
-            msg = "Warning: You disabled the console output plugin. If you"\
+            msg = "\nWarning: You disabled the console output plugin. If you"\
                   " start a new scan, the discovered vulnerabilities won\'t be"\
                   " printed to the console, we advise you to enable at least"\
                   " one output plugin in order to be able to actually see the"\


### PR DESCRIPTION
To fix an issue that would output the warning message
just after the command. Like this:

```
 w3af>>> startWarning: You (...)
```

instead of this:

```
 w3af>>> start
 Warning: You (...)
```
