### PR TITLE
Feature/api basic auth

### DIFF
--- a/doc/sphinx/api/index.rst
+++ b/doc/sphinx/api/index.rst
@@ -55,6 +55,14 @@ For example, using the 'curl' command:
       "docs": "http://docs.w3af.org/en/latest/api/index.html" 
     }
 
+Although this provides some security, traffic passing to and from the API is not
+encrypted, meaning that authentication and vulnerability information could be 
+sniffed by an attacker with "man-in-the-middle" capabilities.
+
+If running the API on a publicly available IP address we recommend taking
+additional precautions including running it behind an SSL proxy server (such as 
+Pound, or Apache with mod_proxy enabled).
+
 Config file format
 ------------------
 

--- a/doc/sphinx/api/index.rst
+++ b/doc/sphinx/api/index.rst
@@ -15,7 +15,7 @@ The REST API can be started by running:
 
 .. code-block:: none
 
-    $ ./w3af_api
+    $ ./w3af_api -p "<SHA512-hashed password for basic authentication>"
      * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
 
 Or it can also be run inside a docker container:
@@ -23,8 +23,61 @@ Or it can also be run inside a docker container:
 .. code-block:: none
 
     $ cd extras/docker/scripts/
-    $ ./w3af_api_docker
+    $ ./w3af_api_docker -c /path/to/config_file.yaml
      * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
+
+A password is required for HTTP basic authentication, and can be specified on
+the command line with the "-p" flag, or in a configuration file with the
+"password:" directive.
+
+To simplify passing options to the API when run with Docker, the helper script
+asks users to create and specify a configuration file.
+
+Authentication
+--------------
+
+Linux or Mac users can generate a SHA512 hash from a plaintext password by
+running:
+
+.. code-block:: none
+    $ echo -n "secret" | sha512sum
+    bd2b1aaf7ef4f09be9f52ce2d8d599674d81aa9d6a4421696dc4d93dd0619d682ce56b4d64a9ef097761ced99e0f67265b5f76085e5b0ee7ca4696b2ad6fe2b2  -
+
+If the above hash was specified using the "password" option, users would be able 
+to authenticate using HTTP basic auth with the default username 'admin' and 
+password 'secret'.
+
+For example, using the 'curl' command:
+
+.. code-block:: none
+    $ curl -u admin:secret http://127.0.0.1:5000
+    {
+      "docs": "http://docs.w3af.org/en/latest/api/index.html" 
+    }
+
+Config file format
+------------------
+
+Using a configuration file is completely optional unless you're starting the
+API using the provided Docker scripts. It's simply a convenient place to put
+configuration options that could otherwise be specified on the command line.
+
+The configuration file is in standard YAML format and accepts any of the options
+found on the command line. A sample configuration file would look like this:
+
+.. code-block:: none
+
+    # This is a comment
+    host: '127.0.0.1'
+    port: 5000
+    verbose: False
+    username: 'admin'
+    # The SHA512-hashed password is 'secret'. We don't recommend using this.
+    password: 'bd2b1aaf7ef4f09be9f52ce2d8d599674d81aa9d6a4421696dc4d93dd0619d682ce56b4d64a9ef097761ced99e0f67265b5f76085e5b0ee7ca4696b2ad6fe2b2'
+
+In the above example, all values except 'password' are the defaults and could
+have been omitted from the configuration file without changing the way the API 
+runs.
 
 REST API Source code
 --------------------

--- a/doc/sphinx/api/index.rst
+++ b/doc/sphinx/api/index.rst
@@ -15,7 +15,7 @@ The REST API can be started by running:
 
 .. code-block:: none
 
-    $ ./w3af_api -p "<SHA512-hashed password for basic authentication>"
+    $ ./w3af_api
      * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
 
 Or it can also be run inside a docker container:
@@ -23,41 +23,43 @@ Or it can also be run inside a docker container:
 .. code-block:: none
 
     $ cd extras/docker/scripts/
-    $ ./w3af_api_docker -c /path/to/config_file.yaml
+    $ ./w3af_api_docker
      * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
-
-A password is required for HTTP basic authentication, and can be specified on
-the command line with the "-p" flag, or in a configuration file with the
-"password:" directive.
-
-To simplify passing options to the API when run with Docker, the helper script
-asks users to create and specify a configuration file.
 
 Authentication
 --------------
+
+It is possible to require HTTP basic authentication for all API views by
+specifying a SHA512-hashed password on the command line (with "-p <SHA512_HASH>")
+or in a configuration file using the "password:" directive (see the section
+below for more information about configuration files).
 
 Linux or Mac users can generate a SHA512 hash from a plaintext password by
 running:
 
 .. code-block:: none
+
     $ echo -n "secret" | sha512sum
     bd2b1aaf7ef4f09be9f52ce2d8d599674d81aa9d6a4421696dc4d93dd0619d682ce56b4d64a9ef097761ced99e0f67265b5f76085e5b0ee7ca4696b2ad6fe2b2  -
 
-If the above hash was specified using the "password" option, users would be able 
-to authenticate using HTTP basic auth with the default username 'admin' and 
-password 'secret'.
+    $ ./w3af_api -p "bd2b1aaf7ef4f09be9f52ce2d8d599674d81aa9d6a4421696dc4d93dd0619d682ce56b4d64a9ef097761ced99e0f67265b5f76085e5b0ee7ca4696b2ad6fe2b2"
+     * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
+
+In the above example, users would be able to connect using HTTP basic
+authentication with the default username 'admin' and the password 'secret'.
 
 For example, using the 'curl' command:
 
 .. code-block:: none
+
     $ curl -u admin:secret http://127.0.0.1:5000
     {
       "docs": "http://docs.w3af.org/en/latest/api/index.html" 
     }
 
-Although this provides some security, traffic passing to and from the API is not
-encrypted, meaning that authentication and vulnerability information could be 
-sniffed by an attacker with "man-in-the-middle" capabilities.
+Please note that even with basic authentication, traffic passing to and from the 
+API is not encrypted, meaning that authentication and vulnerability information 
+could still be sniffed by an attacker with "man-in-the-middle" capabilities.
 
 If running the API on a publicly available IP address we recommend taking
 additional precautions including running it behind an SSL proxy server (such as 
@@ -66,8 +68,7 @@ Pound, or Apache with mod_proxy enabled).
 Config file format
 ------------------
 
-Using a configuration file is completely optional unless you're starting the
-API using the provided Docker scripts. It's simply a convenient place to put
+Using a configuration file is optional and is simply a convenient place to store
 configuration options that could otherwise be specified on the command line.
 
 The configuration file is in standard YAML format and accepts any of the options

--- a/extras/docker/scripts/w3af_api_docker
+++ b/extras/docker/scripts/w3af_api_docker
@@ -9,15 +9,16 @@ from common.docker_helpers import (check_root, create_volumes, start_container,
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument('-d', '--debug', help='Use bash to connect',
+    opts = parser.add_mutually_exclusive_group()
+    opts.add_argument('-d', '--debug', help='Use bash to connect',
                         action='store_true')
     parser.add_argument('-t', '--tag', help='Docker image tag to run. Default'
                                             ' is stable, try unstable to get'
                                             ' the latest w3af features.',
                         required=False)
-    parser.add_argument('-c', '--config-file',
+    opts.add_argument('-c', '--config-file',
                         help='Path to API config file in YAML format.',
-                        required=True, dest=api_config_file)
+                        required=False, dest='api_config_file')
     return parser.parse_args()
 
 
@@ -38,8 +39,10 @@ if __name__ == '__main__':
 
     if args.debug:
         cmd = '/bin/bash'
-    else:
+    elif args.api_config_file: 
         cmd = '/home/w3af/w3af/w3af_api 0.0.0.0:5000 -c %s' % api_config_file
+    else:
+        cmd = '/home/w3af/w3af/w3af_api 0.0.0.0:5000'
 
     try:
         connect_to_container(container_id, cmd)

--- a/extras/docker/scripts/w3af_api_docker
+++ b/extras/docker/scripts/w3af_api_docker
@@ -16,7 +16,7 @@ def parse_args():
                                             ' the latest w3af features.',
                         required=False)
     parser.add_argument('-c', '--config-file',
-                        help='[Required] Path to API config file in YAML format.',
+                        help='Path to API config file in YAML format.',
                         required=True, dest=api_config_file)
     return parser.parse_args()
 

--- a/extras/docker/scripts/w3af_api_docker
+++ b/extras/docker/scripts/w3af_api_docker
@@ -15,6 +15,9 @@ def parse_args():
                                             ' is stable, try unstable to get'
                                             ' the latest w3af features.',
                         required=False)
+    parser.add_argument('-c', '--config-file',
+                        help='[Required] Path to API config file in YAML format.',
+                        required=True, dest=api_config_file)
     return parser.parse_args()
 
 
@@ -36,7 +39,7 @@ if __name__ == '__main__':
     if args.debug:
         cmd = '/bin/bash'
     else:
-        cmd = '/home/w3af/w3af/w3af_api 0.0.0.0:5000'
+        cmd = '/home/w3af/w3af/w3af_api 0.0.0.0:5000 -c %s' % api_config_file
 
     try:
         connect_to_container(container_id, cmd)

--- a/w3af/core/ui/api/main.py
+++ b/w3af/core/ui/api/main.py
@@ -124,11 +124,11 @@ def main():
     args = parse_arguments()
     if args.config_file:
         try:
-          yaml_conf = yaml.safe_load(args.config_file)
+            yaml_conf = yaml.safe_load(args.config_file)
         except:
-          print('Error loading config file %s. Please check it exists and is'
-                ' a valid YAML file.' % args.config_file)
-          return 1
+            print('Error loading config file %s. Please check it exists and is'
+                  ' a valid YAML file.' % args.config_file)
+            return 1
 
         for k in yaml_conf:
             if k.lower() in vars(args) and vars(args)[k.lower()]:
@@ -148,8 +148,8 @@ def main():
             app.config[i.upper()] = vars(args)[i]
 
     try:
-      # Check password has been specified and is a 512-bit hex string
-      # (ie, that it looks like a SHA512 hash)
+        # Check password has been specified and is a 512-bit hex string
+        # (ie, that it looks like a SHA512 hash)
         int(app.config['PASSWORD'], 16) and len(app.config['PASSWORD']) == 128
     except:
         print('Error: Please specify a valid SHA512-hashed plaintext as password,'
@@ -163,8 +163,8 @@ def main():
     app.config['HOST'], app.config['PORT'] = parse_host_port(app.config['HOST'],
                                                              app.config['PORT'])
 
-    if (app.config['HOST'] == '127.0.0.1' or
-        app.config['HOST'] == 'localhost'):
+    if (app.config['HOST'] != '127.0.0.1' and
+        app.config['HOST'] != 'localhost'):
         print('CAUTION! Traffic to this API is not encrypted and could be sniffed.'
               ' Please consider putting this behind an SSL-enabled proxy server.')
 

--- a/w3af/core/ui/api/main.py
+++ b/w3af/core/ui/api/main.py
@@ -130,8 +130,8 @@ def main():
               ' a valid YAML file.' % args.config_file)
         return 1
 
-      for k.lower() in yaml_conf:
-        if k in vars(args) and vars(args)[k]:
+      for k in yaml_conf:
+        if k.lower() in vars(args) and vars(args)[k.lower()]:
           print('Error: you appear to have specified options in the config'
                 ' file and on the command line. Please resolve any conflicting'
                 ' options and try again: %s' % k)

--- a/w3af/core/ui/api/main.py
+++ b/w3af/core/ui/api/main.py
@@ -65,6 +65,7 @@ def parse_arguments():
     parser.add_argument('-c',
                         default=False,
                         dest='config_file',
+                        type=argparse.FileType('r'),
                         help='Path to a config file in YAML format. At minimum,'
                              ' either this OR the "-p" (password) option MUST'
                              ' be provided.')
@@ -123,8 +124,7 @@ def main():
     args = parse_arguments()
     if args.config_file:
         try:
-          with open(args.config_file) as f:
-            yaml_conf = yaml.safe_load(f)
+          yaml_conf = yaml.safe_load(args.config_file)
         except:
           print('Error loading config file %s. Please check it exists and is'
                 ' a valid YAML file.' % args.config_file)

--- a/w3af/core/ui/api/main.py
+++ b/w3af/core/ui/api/main.py
@@ -152,26 +152,41 @@ def main():
         elif i in vars(args) and vars(args)[i]:
             app.config[i.upper()] = vars(args)[i]
 
-    try:
-        # Check password has been specified and is a 512-bit hex string
-        # (ie, that it looks like a SHA512 hash)
-        int(app.config['PASSWORD'], 16) and len(app.config['PASSWORD']) == 128
-    except:
-        print('Error: Please specify a valid SHA512-hashed plaintext as password,'
-              ' either inside a config file with "-c" or using the "-p" flag.')
-        return 1
-    
     for k in defaults:
         if not k in app.config:
             app.config[k] = defaults[k]
 
+    if 'PASSWORD' in app.config:
+        try:
+            # Check password has been specified and is a 512-bit hex string
+            # (ie, that it looks like a SHA512 hash)
+            int(app.config['PASSWORD'], 16) and len(app.config['PASSWORD']) == 128
+        except:
+            print('Error: Please specify a valid SHA512-hashed plaintext as' 
+                  ' password, either inside a config file with "-c" or using the' 
+                  ' "-p" flag.')
+            return 1
+    
     app.config['HOST'], app.config['PORT'] = parse_host_port(app.config['HOST'],
                                                              app.config['PORT'])
 
     if (app.config['HOST'] != '127.0.0.1' and
         app.config['HOST'] != 'localhost'):
-        print('CAUTION! Traffic to this API is not encrypted and could be sniffed.'
-              ' Please consider putting this behind an SSL-enabled proxy server.')
+
+        print('')
+        if not 'PASSWORD' in app.config:
+            print('CAUTION! Running this API on a public IP might expose your'
+                  ' system to vulnerabilities such as arbitrary file reads'
+                  ' through file:// protocol specifications in target URLs and'
+                  ' scan profiles.\n'
+                  'We recommend enabling HTTP basic authentication by specifying'
+                  ' a password on the command line (with "-p <SHA512 hash>") or'
+                  ' in a configuration file.\n')
+
+        print('CAUTION! Traffic to this API is not encrypted and could be'
+              ' sniffed. Please consider putting this behind an SSL-enabled'
+              ' proxy server.\n')
+
 
     try:
         app.run(host=app.config['HOST'], port=app.config['PORT'],

--- a/w3af/core/ui/api/main.py
+++ b/w3af/core/ui/api/main.py
@@ -131,7 +131,9 @@ def main():
             return 1
 
         for k in yaml_conf:
-            if k.lower() in vars(args) and vars(args)[k.lower()]:
+            if type(yaml_conf[k]).__name__ not in ['str', 'int', 'bool']:
+                pass
+            elif k.lower() in vars(args) and vars(args)[k.lower()]:
                 print('Error: you appear to have specified options in the config'
                       ' file and on the command line. Please resolve any'
                       ' conflicting options and try again: %s' % k)
@@ -141,10 +143,13 @@ def main():
        # modified by setting them in the config YAML:
        # http://flask.pocoo.org/docs/latest/config/
 
-            app.config[k.upper()] = yaml_conf[k]
+            else:
+                app.config[k.upper()] = yaml_conf[k]
      
     for i in vars(args):
-        if i in vars(args) and vars(args)[i]:
+        if type(vars(args)[i]).__name__ not in ['str', 'int', 'bool']:
+            pass
+        elif i in vars(args) and vars(args)[i]:
             app.config[i.upper()] = vars(args)[i]
 
     try:

--- a/w3af/core/ui/api/main.py
+++ b/w3af/core/ui/api/main.py
@@ -163,6 +163,11 @@ def main():
     app.config['HOST'], app.config['PORT'] = parse_host_port(app.config['HOST'],
                                                              app.config['PORT'])
 
+    if (app.config['HOST'] == '127.0.0.1' or
+        app.config['HOST'] == 'localhost'):
+      print('CAUTION! Traffic to this API is not encrypted and could be sniffed.'
+            ' Please consider putting this behind an SSL-enabled proxy server.')
+
     try:
         app.run(host=app.config['HOST'], port=app.config['PORT'],
                 debug=args.verbose, use_reloader=False)

--- a/w3af/core/ui/api/main.py
+++ b/w3af/core/ui/api/main.py
@@ -102,12 +102,12 @@ def parse_arguments():
     args = parser.parse_args()
 
     try:
-      args.host, args.port = getattr(args,'host:port').split(':')
+        args.host, args.port = getattr(args,'host:port').split(':')
     except ValueError:
-      raise argparse.ArgumentTypeError('Please specify a valid host and port as'
+        raise argparse.ArgumentTypeError('Please specify a valid host and port as'
                                        ' HOST:PORT (eg "127.0.0.1:5000").')
     except AttributeError:
-      pass # Expect AttributeError if host_port was not entered
+        pass # Expect AttributeError if host_port was not entered
     
     return args
 
@@ -122,51 +122,51 @@ def main():
 
     args = parse_arguments()
     if args.config_file:
-      try:
-        with open(args.config_file) as f:
-          yaml_conf = yaml.safe_load(f)
-      except:
-        print('Error loading config file %s. Please check it exists and is'
-              ' a valid YAML file.' % args.config_file)
-        return 1
-
-      for k in yaml_conf:
-        if k.lower() in vars(args) and vars(args)[k.lower()]:
-          print('Error: you appear to have specified options in the config'
-                ' file and on the command line. Please resolve any conflicting'
-                ' options and try again: %s' % k)
+        try:
+          with open(args.config_file) as f:
+            yaml_conf = yaml.safe_load(f)
+        except:
+          print('Error loading config file %s. Please check it exists and is'
+                ' a valid YAML file.' % args.config_file)
           return 1
 
-      # Flask contains a number of built-in server options that can also be
-      # modified by setting them in the config YAML:
-      # http://flask.pocoo.org/docs/latest/config/
+        for k in yaml_conf:
+            if k.lower() in vars(args) and vars(args)[k.lower()]:
+                print('Error: you appear to have specified options in the config'
+                      ' file and on the command line. Please resolve any'
+                      ' conflicting options and try again: %s' % k)
+                return 1
 
-        app.config[k.upper()] = yaml_conf[k]
+       # Flask contains a number of built-in server options that can also be
+       # modified by setting them in the config YAML:
+       # http://flask.pocoo.org/docs/latest/config/
+
+            app.config[k.upper()] = yaml_conf[k]
      
     for i in vars(args):
-      if i in vars(args) and vars(args)[i]:
-        app.config[i.upper()] = vars(args)[i]
+        if i in vars(args) and vars(args)[i]:
+            app.config[i.upper()] = vars(args)[i]
 
     try:
       # Check password has been specified and is a 512-bit hex string
       # (ie, that it looks like a SHA512 hash)
-      int(app.config['PASSWORD'], 16) and len(app.config['PASSWORD']) == 128
+        int(app.config['PASSWORD'], 16) and len(app.config['PASSWORD']) == 128
     except:
-      print('Error: Please specify a valid SHA512-hashed plaintext as password,'
-            ' either inside a config file with "-c" or using the "-p" flag.')
-      return 1
+        print('Error: Please specify a valid SHA512-hashed plaintext as password,'
+              ' either inside a config file with "-c" or using the "-p" flag.')
+        return 1
     
     for k in defaults:
-      if not k in app.config:
-        app.config[k] = defaults[k]
+        if not k in app.config:
+            app.config[k] = defaults[k]
 
     app.config['HOST'], app.config['PORT'] = parse_host_port(app.config['HOST'],
                                                              app.config['PORT'])
 
     if (app.config['HOST'] == '127.0.0.1' or
         app.config['HOST'] == 'localhost'):
-      print('CAUTION! Traffic to this API is not encrypted and could be sniffed.'
-            ' Please consider putting this behind an SSL-enabled proxy server.')
+        print('CAUTION! Traffic to this API is not encrypted and could be sniffed.'
+              ' Please consider putting this behind an SSL-enabled proxy server.')
 
     try:
         app.run(host=app.config['HOST'], port=app.config['PORT'],

--- a/w3af/core/ui/api/main.py
+++ b/w3af/core/ui/api/main.py
@@ -92,7 +92,7 @@ def parse_arguments():
                         help='Username required for basic auth. If not '
                              'specified, this will be set to "admin".')
 
-    parser.add_argument('-v',
+    opts.add_argument('-v',
                         required=False,
                         default=False,
                         dest='verbose',

--- a/w3af/core/ui/api/main.py
+++ b/w3af/core/ui/api/main.py
@@ -126,8 +126,9 @@ def main():
         try:
             yaml_conf = yaml.safe_load(args.config_file)
         except:
+            file.close(args.config_file)
             print('Error loading config file %s. Please check it exists and is'
-                  ' a valid YAML file.' % args.config_file)
+                  ' a valid YAML file.' % args.config_file.name)
             return 1
 
         for k in yaml_conf:
@@ -145,6 +146,8 @@ def main():
 
             else:
                 app.config[k.upper()] = yaml_conf[k]
+
+        file.close(args.config_file)
      
     for i in vars(args):
         if type(vars(args)[i]).__name__ not in ['str', 'int', 'bool']:

--- a/w3af/core/ui/api/resources/error_handlers.py
+++ b/w3af/core/ui/api/resources/error_handlers.py
@@ -26,6 +26,7 @@ from flask import jsonify
 from os.path import basename
 
 from w3af.core.ui.api import app
+from w3af.core.ui.api.utils.auth import requires_auth
 
 
 @app.errorhandler(404)
@@ -89,6 +90,7 @@ def get_last_call_info(main_tb):
 
 
 @app.route('/raise-500', methods=['GET'])
+@requires_auth
 def raise_500():
     """
     This exists for testing error_500_handler

--- a/w3af/core/ui/api/resources/index.py
+++ b/w3af/core/ui/api/resources/index.py
@@ -20,9 +20,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 """
 from w3af.core.ui.api import app
+from w3af.core.ui.api.utils.auth import requires_auth
 from flask import jsonify
 
 
 @app.route('/', methods=['GET'])
+@requires_auth
 def index():
     return jsonify({'docs': 'http://docs.w3af.org/en/latest/api/index.html'})

--- a/w3af/core/ui/api/resources/kb.py
+++ b/w3af/core/ui/api/resources/kb.py
@@ -25,10 +25,12 @@ import w3af.core.data.kb.knowledge_base as kb
 
 from w3af.core.ui.api import app
 from w3af.core.ui.api.utils.error import abort
+from w3af.core.ui.api.utils.auth import requires_auth
 from w3af.core.ui.api.utils.scans import get_scan_info_from_id
 
 
 @app.route('/scans/<int:scan_id>/kb/', methods=['GET'])
+@requires_auth
 def list_kb(scan_id):
     """
     List vulnerabilities stored in the KB (for a specific scan)
@@ -65,6 +67,7 @@ def list_kb(scan_id):
 
 
 @app.route('/scans/<int:scan_id>/kb/<int:vulnerability_id>', methods=['GET'])
+@requires_auth
 def get_kb(scan_id, vulnerability_id):
     """
     The whole information related to the specified vulnerability ID

--- a/w3af/core/ui/api/resources/scans.py
+++ b/w3af/core/ui/api/resources/scans.py
@@ -25,6 +25,7 @@ from flask import jsonify, request
 
 from w3af.core.ui.api import app
 from w3af.core.ui.api.utils.error import abort
+from w3af.core.ui.api.utils.auth import requires_auth
 from w3af.core.ui.api.db.master import SCANS
 from w3af.core.ui.api.utils.scans import (get_scan_info_from_id,
                                           start_scan_helper,
@@ -36,6 +37,7 @@ from w3af.core.controllers.exceptions import BaseFrameworkException
 
 
 @app.route('/scans/', methods=['POST'])
+@requires_auth
 def start_scan():
     """
     Starts a new w3af scan
@@ -121,6 +123,7 @@ def start_scan():
 
 
 @app.route('/scans/', methods=['GET'])
+@requires_auth
 def list_scans():
     """
     :return: A JSON containing a list of:
@@ -149,6 +152,7 @@ def list_scans():
 
 
 @app.route('/scans/<int:scan_id>', methods=['DELETE'])
+@requires_auth
 def scan_delete(scan_id):
     """
     Clear all the scan information
@@ -171,6 +175,7 @@ def scan_delete(scan_id):
 
 
 @app.route('/scans/<int:scan_id>/status', methods=['GET'])
+@requires_auth
 def scan_status(scan_id):
     """
     :param scan_id: The scan ID
@@ -188,6 +193,7 @@ def scan_status(scan_id):
 
 
 @app.route('/scans/<int:scan_id>/pause', methods=['GET'])
+@requires_auth
 def scan_pause(scan_id):
     """
     Pause a scan
@@ -209,6 +215,7 @@ def scan_pause(scan_id):
 
 
 @app.route('/scans/<int:scan_id>/stop', methods=['GET'])
+@requires_auth
 def scan_stop(scan_id):
     """
     Stop a scan
@@ -232,6 +239,7 @@ def scan_stop(scan_id):
 
 
 @app.route('/scans/<int:scan_id>/log', methods=['GET'])
+@requires_auth
 def scan_log(scan_id):
     """
     :param scan_id: The scan ID to retrieve the scan

--- a/w3af/core/ui/api/resources/traffic.py
+++ b/w3af/core/ui/api/resources/traffic.py
@@ -24,12 +24,14 @@ from flask import jsonify
 
 from w3af.core.ui.api import app
 from w3af.core.ui.api.utils.error import abort
+from w3af.core.ui.api.utils.auth import requires_auth
 from w3af.core.ui.api.utils.scans import get_scan_info_from_id
 from w3af.core.data.db.history import HistoryItem
 from w3af.core.controllers.exceptions import DBException
 
 
 @app.route('/scans/<int:scan_id>/traffic/<int:traffic_id>', methods=['GET'])
+@requires_auth
 def get_traffic_details(scan_id, traffic_id):
     """
     The HTTP request and response associated with a vulnerability, usually the

--- a/w3af/core/ui/api/resources/version.py
+++ b/w3af/core/ui/api/resources/version.py
@@ -22,9 +22,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 from flask import jsonify
 
 from w3af.core.ui.api import app
+from w3af.core.ui.api.utils.auth import requires_auth
 from w3af.core.controllers.misc.get_w3af_version import get_w3af_version_as_dict
 
 
 @app.route('/version', methods=['GET'])
+@requires_auth
 def version():
     return jsonify(get_w3af_version_as_dict())

--- a/w3af/core/ui/api/tests/test_kb.py
+++ b/w3af/core/ui/api/tests/test_kb.py
@@ -33,6 +33,7 @@ class KBApiTest(APIUnitTest):
         data = {'scan_profile': profile,
                 'target_urls': [target_url]}
         response = requests.post('%s/scans/' % self.api_url,
+                                 auth=self.api_auth,
                                  data=json.dumps(data),
                                  headers=self.headers)
 
@@ -48,13 +49,15 @@ class KBApiTest(APIUnitTest):
         # Name filter
         #
         args = (self.api_url, scan_id)
-        response = requests.get('%s/scans/%s/kb/?name=SQL%%20Injection' % args)
+        response = requests.get('%s/scans/%s/kb/?name=SQL%%20Injection' % args,
+                                auth=self.api_auth)
         self.assertEqual(response.status_code, 200, response.text)
 
         vuln_items = response.json()['items']
         self.assertEqual(4, len(vuln_items), self.create_assert_message())
 
-        response = requests.get('%s/scans/%s/kb/?name=Foo' % args)
+        response = requests.get('%s/scans/%s/kb/?name=Foo' % args,
+                                auth=self.api_auth)
         self.assertEqual(response.status_code, 200, response.text)
 
         vuln_items = response.json()['items']
@@ -64,13 +67,15 @@ class KBApiTest(APIUnitTest):
         # URL filter
         #
         extra_args = (self.api_url, scan_id, target_url)
-        response = requests.get('%s/scans/%s/kb/?url=%s' % extra_args)
+        response = requests.get('%s/scans/%s/kb/?url=%s' % extra_args,
+                                auth=self.api_auth)
         self.assertEqual(response.status_code, 200, response.text)
 
         vuln_items = response.json()['items']
         self.assertEqual(4, len(vuln_items))
 
-        response = requests.get('%s/scans/%s/kb/?url=http://google.com/' % args)
+        response = requests.get('%s/scans/%s/kb/?url=http://google.com/' % args,
+                                auth=self.api_auth)
         self.assertEqual(response.status_code, 200, response.text)
 
         vuln_items = response.json()['items']
@@ -80,7 +85,8 @@ class KBApiTest(APIUnitTest):
         # Combined filter
         #
         qs = '%s/scans/%s/kb/?url=%s&name=SQL%%20injection'
-        response = requests.get(qs % extra_args)
+        response = requests.get(qs % extra_args,
+                                auth=self.api_auth)
         self.assertEqual(response.status_code, 200, response.text)
 
         vuln_items = response.json()['items']

--- a/w3af/core/ui/api/tests/test_log.py
+++ b/w3af/core/ui/api/tests/test_log.py
@@ -34,6 +34,7 @@ class ApiScanLogTest(APIUnitTest):
         data = {'scan_profile': profile,
                 'target_urls': [target_url]}
         requests.post('%s/scans/' % self.api_url,
+                      auth=self.api_auth,
                       data=json.dumps(data),
                       headers=self.headers)
 
@@ -46,7 +47,8 @@ class ApiScanLogTest(APIUnitTest):
         #
         # Get the scan log
         #
-        response = requests.get('%s/scans/0/log' % self.api_url)
+        response = requests.get('%s/scans/0/log' % self.api_url,
+                                auth=self.api_auth)
         self.assertEqual(response.status_code, 200, response.text)
 
         log_data_page_0 = response.json()
@@ -60,7 +62,8 @@ class ApiScanLogTest(APIUnitTest):
         self.assertEqual(zero_entry['type'], 'debug')
         self.assertIsNotNone(zero_entry['time'])
 
-        response = requests.get('%s/scans/0/log?page=1' % self.api_url)
+        response = requests.get('%s/scans/0/log?page=1' % self.api_url,
+                                auth=self.api_auth)
         self.assertEqual(response.status_code, 200, response.text)
 
         self.assertNotEqual(log_data_page_0['entries'],

--- a/w3af/core/ui/api/tests/test_scan.py
+++ b/w3af/core/ui/api/tests/test_scan.py
@@ -36,6 +36,7 @@ class APIScanTest(APIUnitTest):
         data = {'scan_profile': profile,
                 'target_urls': [target_url]}
         response = requests.post('%s/scans/' % self.api_url,
+                                 auth=self.api_auth,
                                  data=json.dumps(data),
                                  headers=self.headers)
 
@@ -61,7 +62,8 @@ class APIScanTest(APIUnitTest):
         #
         # Get the detailed status
         #
-        response = requests.get('%s/scans/%s/status' % (self.api_url, scan_id))
+        response = requests.get('%s/scans/%s/status' % (self.api_url, scan_id),
+                                auth=self.api_auth)
         self.assertEqual(response.status_code, 200, response.text)
 
         json_data = response.json()
@@ -74,7 +76,8 @@ class APIScanTest(APIUnitTest):
         #
         self.wait_until_finish()
 
-        response = requests.get('%s/scans/%s/kb/' % (self.api_url, scan_id))
+        response = requests.get('%s/scans/%s/kb/' % (self.api_url, scan_id),
+                                auth=self.api_auth)
         self.assertEqual(response.status_code, 200, response.text)
 
         vuln_summaries = response.json()['items']
@@ -88,7 +91,8 @@ class APIScanTest(APIUnitTest):
         #
         # Make sure I can access the vulnerability details
         #
-        response = requests.get('%s/scans/%s/kb/0' % (self.api_url, scan_id))
+        response = requests.get('%s/scans/%s/kb/0' % (self.api_url, scan_id),
+                                auth=self.api_auth)
         self.assertEqual(response.status_code, 200, response.text)
 
         vuln_info = response.json()
@@ -105,7 +109,8 @@ class APIScanTest(APIUnitTest):
         # Get the HTTP traffic for this vulnerability
         #
         traffic_href = vuln_info['traffic_hrefs'][0]
-        response = requests.get('%s%s' % (self.api_url, traffic_href))
+        response = requests.get('%s%s' % (self.api_url, traffic_href),
+                                auth=self.api_auth)
 
         traffic_data = response.json()
         self.assertIn('request', traffic_data)
@@ -116,7 +121,8 @@ class APIScanTest(APIUnitTest):
         #
         # Get the scan log
         #
-        response = requests.get('%s/scans/%s/log' % (self.api_url, scan_id))
+        response = requests.get('%s/scans/%s/log' % (self.api_url, scan_id),
+                                auth=self.api_auth)
         self.assertEqual(response.status_code, 200, response.text)
 
         log_data = response.json()
@@ -133,7 +139,8 @@ class APIScanTest(APIUnitTest):
         #
         # Clear the scan results
         #
-        response = requests.delete('%s/scans/%s' % (self.api_url, scan_id))
+        response = requests.delete('%s/scans/%s' % (self.api_url, scan_id),
+                                   auth=self.api_auth)
         self.assertEqual(response.json(), {u'message': u'Success'})
 
         return scan_id
@@ -143,6 +150,7 @@ class APIScanTest(APIUnitTest):
         data = {'scan_profile': profile,
                 'target_urls': [target_url]}
         response = requests.post('%s/scans/' % self.api_url,
+                                 auth=self.api_auth, 
                                  data=json.dumps(data),
                                  headers=self.headers)
 
@@ -159,14 +167,16 @@ class APIScanTest(APIUnitTest):
         #
         # Now stop the scan
         #
-        response = requests.get('%s/scans/0/stop' % self.api_url)
+        response = requests.get('%s/scans/0/stop' % self.api_url, 
+                                 auth=self.api_auth)
         self.assertEqual(response.json(), {u'message': u'Stopping scan'})
 
         # Wait for it...
         self.wait_until_finish()
 
         # Assert that we identify the logs associated with stopping the core
-        response = requests.get('%s/scans/0/log' % self.api_url)
+        response = requests.get('%s/scans/0/log' % self.api_url,
+                                auth=self.api_auth)
         self.assertEqual(response.status_code, 200, response.text)
 
         log_data = response.json()['entries']

--- a/w3af/core/ui/api/tests/test_version.py
+++ b/w3af/core/ui/api/tests/test_version.py
@@ -30,7 +30,8 @@ class VersionTest(APIUnitTest):
         #
         # Name filter
         #
-        response = requests.get('%s/version' % self.api_url)
+        response = requests.get('%s/version' % self.api_url,
+                                auth=self.api_auth)
         self.assertEqual(response.status_code, 200, response.text)
 
         version_dict = response.json()

--- a/w3af/core/ui/api/tests/utils/api_process.py
+++ b/w3af/core/ui/api/tests/utils/api_process.py
@@ -21,6 +21,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 """
 import subprocess
 import requests
+import hashlib
 import time
 import sys
 import os
@@ -42,8 +43,11 @@ def start_api():
 
     w3af_api_path = os.path.abspath(os.path.join(ROOT_PATH, '..'))
     python_executable = sys.executable
+    api_auth = ('admin', 'unittests')
 
-    cmd = [python_executable, 'w3af_api', '127.0.0.1:%s' % port]
+    cmd = [python_executable, 'w3af_api', 
+    '-p %s' % sha512(api_auth[1]).hexdigest(),
+    '127.0.0.1:%s' % port]
 
     process = subprocess.Popen(cmd,
                                stdout=dev_null,
@@ -58,7 +62,7 @@ def start_api():
         time.sleep(0.5)
 
         try:
-            response = requests.get(api_url)
+            response = requests.get(api_url, auth=api_auth)
         except:
             if process.pid is None and i > 25:
                 raise RuntimeError('Failed to start the REST API service')
@@ -68,4 +72,4 @@ def start_api():
     else:
         raise RuntimeError('Timed out waiting for REST API service start')
 
-    return process, port, api_url
+    return process, port, api_url, api_auth

--- a/w3af/core/ui/api/tests/utils/api_process.py
+++ b/w3af/core/ui/api/tests/utils/api_process.py
@@ -21,7 +21,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 """
 import subprocess
 import requests
-import hashlib
+from hashlib import sha512
 import time
 import sys
 import os

--- a/w3af/core/ui/api/tests/utils/api_process.py
+++ b/w3af/core/ui/api/tests/utils/api_process.py
@@ -46,7 +46,7 @@ def start_api():
     api_auth = ('admin', 'unittests')
 
     cmd = [python_executable, 'w3af_api', 
-    '-p %s' % sha512(api_auth[1]).hexdigest(),
+    '-p "%s"' % sha512(api_auth[1]).hexdigest(),
     '127.0.0.1:%s' % port]
 
     process = subprocess.Popen(cmd,

--- a/w3af/core/ui/api/tests/utils/api_unittest.py
+++ b/w3af/core/ui/api/tests/utils/api_unittest.py
@@ -36,7 +36,7 @@ class APIUnitTest(unittest.TestCase):
         # Disable requests logging
         logging.getLogger('requests').setLevel(logging.WARNING)
 
-        self.process, self.port, self.api_url = start_api()
+        self.process, self.port, self.api_url, self.api_auth = start_api()
         self.headers = {'Content-type': 'application/json',
                         'Accept': 'application/json'}
 
@@ -72,7 +72,9 @@ class APIUnitTest(unittest.TestCase):
         for _ in xrange(10):
             time.sleep(0.5)
 
-            response = requests.get('%s/scans/' % self.api_url)
+            response = requests.get('%s/scans/' % self.api_url, 
+                                    auth=self.api_auth)
+                                    
             self.assertEqual(response.status_code, 200, response.text)
             if response.json()['items'][0]['status'] != 'Stopped':
                 return response
@@ -87,7 +89,8 @@ class APIUnitTest(unittest.TestCase):
         for _ in xrange(wait_loops):
             time.sleep(0.5)
 
-            response = requests.get('%s/scans/' % self.api_url)
+            response = requests.get('%s/scans/' % self.api_url, 
+                                    auth=self.api_auth)
             self.assertEqual(response.status_code, 200, response.text)
             if response.json()['items'][0]['status'] != 'Running':
                 return response
@@ -99,10 +102,12 @@ class APIUnitTest(unittest.TestCase):
         :return: A string with a message I can use to debug issues, contains
                  the scan log information available in the REST API (if any)
         """
-        response = requests.get('%s/scans/' % self.api_url)
+        response = requests.get('%s/scans/' % self.api_url, 
+                                auth=self.api_auth)
         scan_id = response.json()['items'][0]['id']
 
-        response = requests.get('%s/scans/%s/log' % (self.api_url, scan_id))
+        response = requests.get('%s/scans/%s/log' % (self.api_url, scan_id),
+                                auth=self.api_auth)
         scan_log = '\n'.join([m['message'] for m in response.json()['entries']])
 
         self.maxDiff = None

--- a/w3af/core/ui/api/utils/auth.py
+++ b/w3af/core/ui/api/utils/auth.py
@@ -1,0 +1,43 @@
+"""
+auth.py
+
+Copyright 2015 Andres Riancho
+
+This file is part of w3af, http://w3af.org/ .
+
+w3af is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation version 2 of the License.
+
+w3af is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with w3af; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+"""
+from functools import wraps
+from flask import request
+from hashlib import sha512
+from w3af.core.ui.api import app
+from w3af.core.ui.api.utils.error import abort
+
+def check_auth(username, password):
+    """This function is called to check if a username /
+    password combination is valid.
+    """
+    return (username == app.config['USERNAME'] and
+            sha512(password).hexdigest() == app.config['PASSWORD'])
+
+def requires_auth(f):
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        auth = request.authorization
+        if not auth or not check_auth(auth.username, auth.password):
+           abort(401, 'Could not verify access. Please specify a username and \
+             password for HTTP basic authentication.')
+        return f(*args, **kwargs)
+    return decorated

--- a/w3af/core/ui/api/utils/auth.py
+++ b/w3af/core/ui/api/utils/auth.py
@@ -35,6 +35,8 @@ def check_auth(username, password):
 def requires_auth(f):
     @wraps(f)
     def decorated(*args, **kwargs):
+        if not 'PASSWORD' in app.config: # Auth was not enabled at startup
+            return f(*args, **kwargs)
         auth = request.authorization
         if not auth or not check_auth(auth.username, auth.password):
            abort(401, 'Could not verify access. Please specify a username and \


### PR DESCRIPTION
#10615 - Add basic auth to REST API

```
Adds @requires_auth decorator to API, which checks basic auth against a SHA512-hashed password
Adds CLI options for 'username' and 'password'
Adds YAML configuration option for API (using CLI option "-c /path/to/file.yaml")
Updates API tests, Docker API script and documentation to reflect the change
```

Note that this breaks backwards compatibility by forcing a requirement for authentication on all views (ie users must specify a password hash either on the CLI or in a configuration file - there's no default). It also requires users running the Docker script to specify a configuration file containing at minimum their hashed password.

I'm happy to refactor that if we would prefer to make basic authentication optional and retain backward compatibility.
