### PR TITLE
SSL Support For the API

### DIFF
--- a/w3af/core/ui/api/main.py
+++ b/w3af/core/ui/api/main.py
@@ -24,7 +24,7 @@ import argparse
 
 from w3af.core.ui.api import app
 from w3af.core.ui.api.utils.cli import process_cmd_args_config
-
+from w3af.core.ui.api.utils.digital_certificate import SSLCertifiacate
 
 def main():
     """
@@ -39,8 +39,12 @@ def main():
 
     # And finally start the app:
     try:
-        app.run(host=app.config['HOST'], port=app.config['PORT'],
-                debug=args.verbose, use_reloader=False, threaded=True)
+        if args.disableSSL:
+            app.run(host=app.config['HOST'], port=app.config['PORT'],
+                    debug=args.verbose, use_reloader=False, threaded=True)
+        else:
+            app.run(host=app.config['HOST'], port=app.config['PORT'],
+                    debug=args.verbose, use_reloader=False, ssl_context=SSLCertifiacate().get())
     except socket.error, se:
         print('Failed to start REST API server: %s' % se.strerror)
         return 1

--- a/w3af/core/ui/api/main.py
+++ b/w3af/core/ui/api/main.py
@@ -21,6 +21,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 """
 import socket
 import argparse
+import ssl
 
 from w3af.core.ui.api import app
 from w3af.core.ui.api.utils.cli import process_cmd_args_config
@@ -39,8 +40,16 @@ def main():
 
     # And finally start the app:
     try:
-        app.run(host=app.config['HOST'], port=app.config['PORT'],
-                debug=args.verbose, use_reloader=False, threaded=True)
+        if args.disableSSL:
+            app.run(host=app.config['HOST'], port=app.config['PORT'],
+                    debug=args.verbose, use_reloader=False, threaded=True)
+        else:
+            context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+            context.load_cert_chain('ssl/w3af.cert', 'ssl/w3af.key')
+
+            app.run(host=app.config['HOST'], port=app.config['PORT'],
+                    debug=args.verbose, use_reloader=False, ssl_context=context)
+
     except socket.error, se:
         print('Failed to start REST API server: %s' % se.strerror)
         return 1

--- a/w3af/core/ui/api/utils/cli.py
+++ b/w3af/core/ui/api/utils/cli.py
@@ -61,6 +61,12 @@ def parse_arguments():
                         default=False,
                         nargs='?')
 
+    parser.add_argument('--no-ssl',
+                        dest="disableSSL",
+                        action="store_true",
+                        help="Disable SSL Support"
+                        )
+
     parser.add_argument('-c',
                         default=False,
                         dest='config_file',
@@ -182,8 +188,5 @@ def process_cmd_args_config(app):
                   ' specifying a password on the command line (with'
                   ' "-p <SHA512 hash>") or in a configuration file.\n')
 
-        print('CAUTION! Traffic to this API is not encrypted and could be'
-              ' sniffed. Please consider serving it behind an SSL-enabled'
-              ' proxy server.\n')
 
     return args

--- a/w3af/core/ui/api/utils/cli.py
+++ b/w3af/core/ui/api/utils/cli.py
@@ -19,10 +19,12 @@ along with w3af; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 """
-import yaml
 import argparse
-
 from argparse import ArgumentTypeError
+
+import yaml
+
+
 
 
 # Global default values
@@ -60,6 +62,12 @@ def parse_arguments():
                              '5000 will be used.',
                         default=False,
                         nargs='?')
+
+    parser.add_argument('--no-ssl',
+                        dest="disableSSL",
+                        action="store_true",
+                        help="Disable SSL Support"
+                        )
 
     parser.add_argument('-c',
                         default=False,

--- a/w3af/core/ui/api/utils/digital_certificate.py
+++ b/w3af/core/ui/api/utils/digital_certificate.py
@@ -1,0 +1,49 @@
+from w3af.core.controllers.misc.homeDir import get_home_dir
+import os
+
+from OpenSSL import crypto
+import socket,ssl
+
+class SSLCertifiacate:
+    def __init__(self):
+        ssl_dir = os.path.join(get_home_dir(),"ssl")
+        self.key_path = os.path.join(ssl_dir,"w3af.key")
+        self.cert_path = os.path.join(ssl_dir,"w3af.crt")
+        if not os.path.exists(ssl_dir):
+                os.makedirs(ssl_dir)
+
+
+    def generate(self,host=None):
+        if host is None:
+            host =  socket.gethostname()
+            key = crypto.PKey()
+            key.generate_key( crypto.TYPE_RSA, 2048)
+            cert = crypto.X509()
+            cert.get_subject().C = "IN"
+            cert.get_subject().ST = "TN"
+            cert.get_subject().L = "w3af"
+            cert.get_subject().O = "W3AF"
+            cert.get_subject().OU = "W3AF"
+            cert.get_subject().CN = host
+            cert.set_serial_number(1111)
+            cert.gmtime_adj_notBefore(0)
+            cert.gmtime_adj_notAfter(10*365*24*60*60)
+            cert.set_issuer(cert.get_subject())
+            cert.set_pubkey(key)
+            cert.sign(key, "sha1")
+
+            with open(self.cert_path,"w") as f:
+                f.write(crypto.dump_certificate(crypto.FILETYPE_PEM, cert))
+
+            with open(self.key_path,"w") as f:
+                f.write(crypto.dump_privatekey(crypto.FILETYPE_PEM, key))
+
+
+    def get(self):
+        if not os.path.exists(self.cert_path) or not  os.path.exists(self.cert_path):
+            self.generate()
+        context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+        context.load_cert_chain(self.cert_path, self.key_path)
+        return context
+
+


### PR DESCRIPTION
I've added the SSL Support for the API.  You can place the ssl key & certificate in the root directory of w3af (Eg: w3af/ssl/w3af.cert)
