### PR TITLE
SSL Support For the API

### DIFF
--- a/w3af/core/ui/api/main.py
+++ b/w3af/core/ui/api/main.py
@@ -26,6 +26,8 @@ from w3af.core.ui.api import app
 from w3af.core.ui.api.utils.cli import process_cmd_args_config
 from w3af.core.controllers.dependency_check.dependency_check import dependency_check
 
+from w3af.core.ui.api.utils.digital_certificate import SSLCertifiacate
+
 
 def main():
     """
@@ -43,8 +45,13 @@ def main():
 
     # And finally start the app:
     try:
-        app.run(host=app.config['HOST'], port=app.config['PORT'],
-                debug=args.verbose, use_reloader=False, threaded=True)
+
+        if args.disableSSL:
+            app.run(host=app.config['HOST'], port=app.config['PORT'],
+                    debug=args.verbose, use_reloader=False, threaded=True)
+        else:
+            app.run(host=app.config['HOST'], port=app.config['PORT'],
+                    debug=args.verbose, use_reloader=False, threaded=True, ssl_context=SSLCertifiacate().get())
     except socket.error, se:
         print('Failed to start REST API server: %s' % se.strerror)
         return 1

--- a/w3af/core/ui/api/utils/cli.py
+++ b/w3af/core/ui/api/utils/cli.py
@@ -61,6 +61,12 @@ def parse_arguments():
                         default=False,
                         nargs='?')
 
+    parser.add_argument('--no-ssl',
+                        dest="disableSSL",
+                        action="store_true",
+                        help="Disable SSL Support"
+                        )
+
     parser.add_argument('-c',
                         default=False,
                         dest='config_file',

--- a/w3af/core/ui/api/utils/digital_certificate.py
+++ b/w3af/core/ui/api/utils/digital_certificate.py
@@ -1,0 +1,46 @@
+from w3af.core.controllers.misc.homeDir import get_home_dir
+import os
+
+from OpenSSL import crypto
+import socket, ssl
+
+
+class SSLCertifiacate:
+    def __init__(self):
+        ssl_dir = os.path.join(get_home_dir(), "ssl")
+        self.key_path = os.path.join(ssl_dir, "w3af.key")
+        self.cert_path = os.path.join(ssl_dir, "w3af.crt")
+        if not os.path.exists(ssl_dir):
+            os.makedirs(ssl_dir)
+
+    def generate(self, host=None):
+        if host is None:
+            host = socket.gethostname()
+            key = crypto.PKey()
+            key.generate_key(crypto.TYPE_RSA, 2048)
+            cert = crypto.X509()
+            cert.get_subject().C = "IN"
+            cert.get_subject().ST = "TN"
+            cert.get_subject().L = "w3af"
+            cert.get_subject().O = "W3AF"
+            cert.get_subject().OU = "W3AF"
+            cert.get_subject().CN = host
+            cert.set_serial_number(111111111111111111111111111)
+            cert.gmtime_adj_notBefore(0)
+            cert.gmtime_adj_notAfter(10 * 365 * 24 * 60 * 60)
+            cert.set_issuer(cert.get_subject())
+            cert.set_pubkey(key)
+            cert.sign(key, "sha256")
+
+            with open(self.cert_path, "w") as f:
+                f.write(crypto.dump_certificate(crypto.FILETYPE_PEM, cert))
+
+            with open(self.key_path, "w") as f:
+                f.write(crypto.dump_privatekey(crypto.FILETYPE_PEM, key))
+
+    def get(self):
+        if not os.path.exists(self.cert_path) or not os.path.exists(self.cert_path):
+            self.generate()
+        context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+        context.load_cert_chain(self.cert_path, self.key_path)
+        return context


### PR DESCRIPTION
Added SSL Support to the API.  Automatically creates Self-Signed Certificate and places the files under ~/.w3af/ssl/ , if the cert file not present. User can disable ssl support with "--no-ssl"
