### PR TITLE
New CSP module and grep plugin

### DIFF
--- a/w3af/core/controllers/csp/tests/test_csp_utils.py
+++ b/w3af/core/controllers/csp/tests/test_csp_utils.py
@@ -346,7 +346,7 @@ class TestUtils(unittest.TestCase):
         """
         Test case in which we add untrusted hosts into somes policies.
         """  
-        header_value = "default-src 'self'; script-src 'self' trust.com evil.com;"
+        header_value = "default-src 'self'; script-src blob: data: 'self' trust.com evil.com;"
         csp = CSPPolicy()
         csp.trusted_hosts = ['trust.com']
         csp.init_value(header_value)

--- a/w3af/core/controllers/csp/tests/test_csp_utils.py
+++ b/w3af/core/controllers/csp/tests/test_csp_utils.py
@@ -412,3 +412,15 @@ class TestUtils(unittest.TestCase):
         csp2.init_from_response(http_response)
  
         self.assertEqual(len(csp1.find_nonce_vulns([csp2])), 1)
+
+    def test_retrieve_csp_policies_with_hashes(self):
+        """
+        Test case in which directive includes hashes.
+        """
+        header_value = "script-src 'sha256-nP0EI9B9ad8IoFUti2q7EQBabcE5MS5v0nkvRfUbYnM='"\
+                " 'sha256-pH+KSy1ZHTi4vu+kNocszrH0NtTuvixRZIV38uhbnlM=';"
+        csp = CSPPolicy()
+        csp.init_value(header_value)
+        d = csp.get_directive_by_name("script-src")
+        self.assertIsNotNone(d)
+        self.assertEqual(len(d.source_list), 2) 

--- a/w3af/core/controllers/csp/tests/test_csp_utils.py
+++ b/w3af/core/controllers/csp/tests/test_csp_utils.py
@@ -25,36 +25,11 @@ import unittest
 from w3af.core.data.url.HTTPResponse import HTTPResponse
 from w3af.core.data.parsers.doc.url import URL
 from w3af.core.data.dc.headers import Headers
-from w3af.core.controllers.csp.utils import (unsafe_inline_enabled,
-                                             retrieve_csp_report_uri,
-                                             provides_csp_features,
-                                             retrieve_csp_policies,
-                                             find_vulns,
-                                             site_protected_against_xss_by_csp,
-                                             CSP_HEADER_CHROME,
-                                             CSP_HEADER_FIREFOX,
-                                             CSP_HEADER_W3C,
-                                             CSP_DIRECTIVE_OBJECT,
-                                             CSP_DIRECTIVE_DEFAULT,
-                                             CSP_DIRECTIVE_IMAGE,
-                                             CSP_DIRECTIVE_SCRIPT,
-                                             CSP_DIRECTIVE_CONNECTION,
-                                             CSP_HEADER_W3C_REPORT_ONLY,
-                                             CSP_DIRECTIVE_REPORT_URI,
-                                             CSP_DIRECTIVE_VALUE_UNSAFE_INLINE,
-                                             CSP_DIRECTIVE_STYLE,
-                                             CSP_DIRECTIVE_FORM,
-                                             CSP_DIRECTIVE_SANDBOX,
-                                             CSP_DIRECTIVE_SCRIPT_NONCE,
-                                             CSP_DIRECTIVE_PLUGIN_TYPES,
-                                             CSP_DIRECTIVE_XSS,
-                                             CSP_DIRECTIVE_MEDIA,
-                                             CSP_DIRECTIVE_FRAME,
-                                             CSP_DIRECTIVE_FONT,
-                                             CSP_MISSPELLED_DIRECTIVES)
-
+from w3af.core.controllers.csp.utils import CSP, CSPPolicy
 
 class TestUtils(unittest.TestCase):
+    header = 'Content-Security-Policy'
+    header_report_only = 'Content-Security-Policy-Report-Only'
 
     def setUp(self):
         self.url = URL('http://moth/')
@@ -64,17 +39,10 @@ class TestUtils(unittest.TestCase):
         Test case in which site do not provides "unsafe-inline" related CSP
         (no directive value "unsafe-inline").
         """
-        hrds = {}
-        hrds[CSP_HEADER_FIREFOX] = CSP_DIRECTIVE_SCRIPT + " 'self'"
-        hrds[CSP_HEADER_W3C_REPORT_ONLY] = CSP_DIRECTIVE_DEFAULT + \
-            " 'self';" + CSP_DIRECTIVE_REPORT_URI + " http://example.com"
-        hrds[CSP_HEADER_W3C] = CSP_DIRECTIVE_SCRIPT + " 'self';" + \
-            CSP_DIRECTIVE_REPORT_URI + " /myrelativeuri"
-        
-        csp_headers = Headers(hrds.items())
-        http_response = HTTPResponse(200, '', csp_headers, self.url, self.url)
-        
-        self.assertFalse(unsafe_inline_enabled(http_response))
+        csp_value = "script-src 'self'; report-uri /myrelativeuri"
+        csp = CSPPolicy()
+        csp.init_value(csp_value)
+        self.assertFalse(csp.unsafe_inline_enabled())
 
     def test_unsafe_inline_enabled_no_case02(self):
         """
@@ -82,88 +50,56 @@ class TestUtils(unittest.TestCase):
         (directive value "unsafe-inline" for a directive other than Script or
         Style).
         """
-        hrds = {}
-        hrds[CSP_HEADER_FIREFOX] = CSP_DIRECTIVE_IMAGE + " '" + \
-            CSP_DIRECTIVE_VALUE_UNSAFE_INLINE + "'"
-        hrds[CSP_HEADER_W3C_REPORT_ONLY] = CSP_DIRECTIVE_DEFAULT + \
-            " 'self';" + CSP_DIRECTIVE_REPORT_URI + " http://example.com"
-        hrds[CSP_HEADER_W3C] = CSP_DIRECTIVE_SCRIPT + " 'self';" + \
-            CSP_DIRECTIVE_REPORT_URI + " /myrelativeuri"
-        
-        csp_headers = Headers(hrds.items())
-        http_response = HTTPResponse(200, '', csp_headers, self.url, self.url)
-        
-        self.assertFalse(unsafe_inline_enabled(http_response))
+        csp_value = "default-src 'none'; img-src 'unsafe-inline'"
+        csp = CSPPolicy()
+        csp.init_value(csp_value)
+        self.assertFalse(csp.unsafe_inline_enabled())
 
     def test_unsafe_inline_enabled_yes_case01(self):
         """
         Test case in which site provides "unsafe-inline" related CSP for
         script.
         """
-        hrds = {}
-        hrds[CSP_HEADER_FIREFOX] = CSP_DIRECTIVE_SCRIPT + " '" + \
-            CSP_DIRECTIVE_VALUE_UNSAFE_INLINE + "'"
-        hrds[CSP_HEADER_W3C] = CSP_DIRECTIVE_SCRIPT + " 'self';" + \
-            CSP_DIRECTIVE_REPORT_URI + " /myrelativeuri"
-        
-        csp_headers = Headers(hrds.items())
-        http_response = HTTPResponse(200, '', csp_headers, self.url, self.url)
-        
-        self.assertTrue(unsafe_inline_enabled(http_response))
+        csp_value =  "script-src 'unsafe-inline'"
+        csp = CSPPolicy()
+        csp.init_value(csp_value)
+        self.assertTrue(csp.unsafe_inline_enabled())
 
     def test_unsafe_inline_enabled_yes_case02(self):
         """
         Test case in which site provides "unsafe-inline" related CSP for
         Style.
         """
-        hrds = {}
-        hrds[CSP_HEADER_FIREFOX] = CSP_DIRECTIVE_STYLE + " '" + \
-            CSP_DIRECTIVE_VALUE_UNSAFE_INLINE + "'"
-        hrds[CSP_HEADER_W3C] = CSP_DIRECTIVE_SCRIPT + " 'self';" + \
-            CSP_DIRECTIVE_REPORT_URI + " /myrelativeuri"
-        
-        csp_headers = Headers(hrds.items())
-        http_response = HTTPResponse(200, '', csp_headers, self.url, self.url)
-        
-        self.assertTrue(unsafe_inline_enabled(http_response))
+        csp_value =  "style-src 'unsafe-inline'"
+        csp = CSPPolicy()
+        csp.init_value(csp_value)
+        self.assertTrue(csp.unsafe_inline_enabled())
 
     def test_retrieve_csp_report_uri_no(self):
         """
         Test case in which site do not provides CSP report uri.
         """
-        hrds = {}.items()
-        csp_headers = Headers(hrds)
-        http_response = HTTPResponse(200, '', csp_headers, self.url, self.url)
-        uri_set = retrieve_csp_report_uri(http_response)
-        self.assertEqual(len(uri_set), 0)
+        csp = CSPPolicy()
+        csp.init_value('')
+        uri_set = csp.get_report_uri()
+        self.assertIsNone(uri_set)
 
     def test_retrieve_csp_report_uri_yes(self):
         """
         Test case in which site provides CSP report uri.
         """
-        hrds = {}
-        hrds[CSP_HEADER_FIREFOX] = CSP_DIRECTIVE_OBJECT + " 'self'"
-        hrds[CSP_HEADER_W3C_REPORT_ONLY] = CSP_DIRECTIVE_DEFAULT + \
-            " 'self';" + CSP_DIRECTIVE_REPORT_URI + " http://example.com"
-        hrds[CSP_HEADER_W3C] = CSP_DIRECTIVE_SCRIPT + " 'self';" + \
-            CSP_DIRECTIVE_REPORT_URI + " /myrelativeuri"
-        
-        csp_headers = Headers(hrds.items())
-        http_response = HTTPResponse(200, '', csp_headers, self.url, self.url)
-        uri_set = retrieve_csp_report_uri(http_response)
-        
-        self.assertEqual(len(uri_set), 2)
-        self.assertTrue("http://example.com" in uri_set)
-        self.assertTrue("/myrelativeuri" in uri_set)
+        csp_value =  "default-src 'self'; report-uri foo.com/myrelativeuri"
+        csp = CSPPolicy()
+        csp.init_value(csp_value)
+        uri_set = csp.get_report_uri()
+        self.assertEqual("foo.com/myrelativeuri", uri_set)
 
     def test_provides_csp_features_no_case01(self):
         """
         Test case in which site do not provides CSP features.
         """
-        hrds = {}.items()
-        csp_headers = Headers(hrds)
-        http_response = HTTPResponse(200, '', csp_headers, self.url, self.url)
-        self.assertFalse(provides_csp_features(http_response))
+        csp = CSPPolicy()
+        self.assertFalse(csp.init_from_header('', ''))
 
     def test_provides_csp_features_no_case02(self):
         """
@@ -173,27 +109,17 @@ class TestUtils(unittest.TestCase):
         #     default-src -> default-source
         #     img-src -> image-src
         header_value = "default-source 'self'; image-src *"
-        hrds = {CSP_HEADER_W3C: header_value}.items()
-        csp_headers = Headers(hrds)
-        
-        http_response = HTTPResponse(200, '', csp_headers, self.url, self.url)
-        
-        self.assertFalse(provides_csp_features(http_response))
+        csp = CSPPolicy()
+        self.assertFalse(csp.init_value(header_value))
 
     def test_provides_csp_features_no_case03(self):
         """
-        Test case in which site provides broken CSP.
+        Test case in which site provides broken CSP 2.
         """
-        # Note the errors in the directive:
-        #     default-src -> default-source
-        #     img-src -> image-src
         header_value = "default-src ' '; img-src ' '"
-        hrds = {CSP_HEADER_W3C: header_value}.items()
-        csp_headers = Headers(hrds)
-        
-        http_response = HTTPResponse(200, '', csp_headers, self.url, self.url)
-                
-        self.assertFalse(provides_csp_features(http_response))
+        csp = CSPPolicy()
+        print csp.init_value(header_value), csp.directives
+        self.assertFalse(csp.init_value(header_value))
         
     def test_provides_csp_features_yes_case01(self):
         """
@@ -204,12 +130,8 @@ class TestUtils(unittest.TestCase):
                        " object-src media1.example.com media2.example.com"\
                        " *.cdn.example.com; script-src"\
                        " trustedscripts.example.com"
-        hrds = {CSP_HEADER_W3C: header_value}.items()
-        csp_headers = Headers(hrds)
-        
-        http_response = HTTPResponse(200, '', csp_headers, self.url, self.url)
-        
-        self.assertTrue(provides_csp_features(http_response))
+        csp = CSPPolicy()
+        self.assertTrue(csp.init_value(header_value))
         
     def test_provides_csp_features_yes_case02(self):
         """
@@ -220,352 +142,119 @@ class TestUtils(unittest.TestCase):
                        " media1.example.com media2.example.com"\
                        " *.cdn.example.com; script-src"\
                        " trustedscripts.example.com"
-        hrds = {CSP_HEADER_W3C_REPORT_ONLY: header_value}.items()
-        csp_headers = Headers(hrds)
-        
-        http_response = HTTPResponse(200, '', csp_headers, self.url, self.url)
-        
-        self.assertTrue(provides_csp_features(http_response))
-
-    def test_provides_csp_features_yes_case03(self):
-        """
-        Test case in which site provides CSP features using report-only +
-        mandatory policies.
-        """
-        hrds = {}
-        hrds[CSP_HEADER_W3C] = CSP_DIRECTIVE_OBJECT + " 'self'"
-        hrds[CSP_HEADER_W3C_REPORT_ONLY] = CSP_DIRECTIVE_CONNECTION + " *"
-        csp_headers = Headers(hrds.items())
-        
-        http_response = HTTPResponse(200, '', csp_headers, self.url, self.url)
-        
-        self.assertTrue(provides_csp_features(http_response))
+        csp = CSPPolicy()
+        self.assertTrue(csp.init_from_header('Content-Security-Policy-Report-Only', header_value))
 
     def test_retrieve_csp_policies_without_policies(self):
         """
         Test case in which no policies are specified into HTTP response.
         """
-        hrds = {}.items()
-        csp_headers = Headers(hrds)
+        csp_headers = Headers({}.items())
         http_response = HTTPResponse(200, '', csp_headers, self.url, self.url)
-        policies = retrieve_csp_policies(http_response)
-        self.assertEqual(len(policies), 0)
+        csp = CSP()
+        self.assertFalse(csp.init_from_response(http_response))
 
-    def test_retrieve_csp_policies_with_policies_case01(self):
+    def test_retrieve_csp_policies_with_directives_case02(self):
         """
-        Test case in which 1 same policy is specified using 3 differents CSP
-        headers.
-        """
-        hrds = {}
-        hrds[CSP_HEADER_W3C] = CSP_DIRECTIVE_OBJECT + " 'self'"
-        hrds[CSP_HEADER_FIREFOX] = CSP_DIRECTIVE_OBJECT + " *"
-        hrds[CSP_HEADER_CHROME] = CSP_DIRECTIVE_OBJECT + " *.sample.com"
-        csp_headers = Headers(hrds.items())
-        
-        http_response = HTTPResponse(200, '', csp_headers, self.url, self.url)
-        
-        policies = retrieve_csp_policies(http_response)
-        
-        self.assertEqual(len(policies), 1)
-        self.assertEqual(len(policies[CSP_DIRECTIVE_OBJECT]), 3)
-        self.assertTrue("self" in policies[CSP_DIRECTIVE_OBJECT])
-        self.assertTrue("*" in policies[CSP_DIRECTIVE_OBJECT])
-        self.assertTrue("*.sample.com" in policies[CSP_DIRECTIVE_OBJECT])
-
-    def test_retrieve_csp_policies_with_policies_case02(self):
-        """
-        Test case in which several policies are specified using only 1 CSP
-        header but with 7 differents directives.
+        Test case in which several directives are specified using only 1 CSP
+        header but with 6 differents directives.
         """
         header_value = "default-src 'self'; img-src *;"\
                        " object-src media1.example.com media2.example.com"\
                        " *.cdn.example.com; script-src trustedscripts.example.com;"\
-                       " form-action /ctxroot/action1 /ctxroot/action2;"\
-                       " plugin-types application/pdf application/x-java-applet;"\
-                       " reflected-xss block"
-        hrds = {CSP_HEADER_W3C: header_value}.items()
-        csp_headers = Headers(hrds)
+                       " form-action foo.com/ctxroot/action1 foo.com/ctxroot/action2;"\
+                       " plugin-types application/pdf audio/ogg;"
+        csp = CSPPolicy()
+        csp.init_value(header_value)
         
-        http_response = HTTPResponse(200, '', csp_headers, self.url, self.url)
-        policies = retrieve_csp_policies(http_response)
-        
-        self.assertEqual(len(policies), 7)
-        self.assertEqual(len(policies[CSP_DIRECTIVE_DEFAULT]), 1)
-        self.assertEqual(policies[CSP_DIRECTIVE_DEFAULT][0], "self")
-        self.assertEqual(len(policies[CSP_DIRECTIVE_IMAGE]), 1)
-        self.assertEqual(policies[CSP_DIRECTIVE_IMAGE][0], "*")
-        self.assertEqual(len(policies[CSP_DIRECTIVE_SCRIPT]), 1)
-        self.assertEqual(
-            policies[CSP_DIRECTIVE_SCRIPT][0], "trustedscripts.example.com")
-        self.assertEqual(len(policies[CSP_DIRECTIVE_OBJECT]), 3)
-        self.assertTrue("media1.example.com" in policies[CSP_DIRECTIVE_OBJECT])
-        self.assertTrue("media2.example.com" in policies[CSP_DIRECTIVE_OBJECT])
-        self.assertTrue("*.cdn.example.com" in policies[CSP_DIRECTIVE_OBJECT])
-        self.assertEqual(len(policies[CSP_DIRECTIVE_FORM]), 2)
-        self.assertTrue("/ctxroot/action1" in policies[CSP_DIRECTIVE_FORM])
-        self.assertTrue("/ctxroot/action2" in policies[CSP_DIRECTIVE_FORM])
-        self.assertEqual(len(policies[CSP_DIRECTIVE_PLUGIN_TYPES]), 2)
-        self.assertTrue(
-            "application/pdf" in policies[CSP_DIRECTIVE_PLUGIN_TYPES])
-        self.assertTrue(
-            "application/x-java-applet" in policies[CSP_DIRECTIVE_PLUGIN_TYPES])
-        self.assertEqual(len(policies[CSP_DIRECTIVE_XSS]), 1)
-        self.assertTrue("block" in policies[CSP_DIRECTIVE_XSS])                        
+        self.assertEqual(len(csp.directives), 6)
+        d = csp.get_directive_by_name("default-src")
+        self.assertIsNotNone(d)
+        self.assertEqual(d.source_list[0], "'self'")
+        d = csp.get_directive_by_name("img-src")
+        self.assertIsNotNone(d)
+        self.assertEqual(d.source_list[0], "*")
+        d = csp.get_directive_by_name("script-src")
+        self.assertIsNotNone(d)
+        self.assertEqual(d.source_list[0], "trustedscripts.example.com")
+        d = csp.get_directive_by_name("object-src")
+        self.assertIsNotNone(d)
+        self.assertTrue("media1.example.com" in d.source_list)
+        self.assertTrue("media2.example.com" in d.source_list)
+        self.assertTrue("*.cdn.example.com" in d.source_list)
+        d = csp.get_directive_by_name("form-action")
+        self.assertEqual(len(d.source_list), 2)
+        self.assertTrue("foo.com/ctxroot/action1" in d.source_list)
+        self.assertTrue("foo.com/ctxroot/action2" in d.source_list)
+        d = csp.get_directive_by_name("plugin-types")
+        self.assertEqual(len(d.media_type_list), 2)
+        self.assertTrue("application/pdf" in d.media_type_list)
+        self.assertTrue("audio/ogg" in d.media_type_list)
 
-    def test_retrieve_csp_policies_with_policies_case03(self):
-        """
-        Test case in which 3 policies are specified using 3 differents CSP headers.
-        """
-        hrds = {}
-        hrds[CSP_HEADER_W3C] = CSP_DIRECTIVE_OBJECT + " 'none'"
-        hrds[CSP_HEADER_FIREFOX] = CSP_DIRECTIVE_IMAGE + " *"
-        hrds[CSP_HEADER_CHROME] = CSP_DIRECTIVE_CONNECTION + \
-            " trust.sample.com"
-        csp_headers = Headers(hrds.items())
-        
-        http_response = HTTPResponse(200, '', csp_headers, self.url, self.url)
-        policies = retrieve_csp_policies(http_response)
-        
-        self.assertEqual(len(policies), 3)
-        self.assertEqual(len(policies[CSP_DIRECTIVE_OBJECT]), 1)
-        self.assertEqual(policies[CSP_DIRECTIVE_OBJECT][0], "none")
-        self.assertEqual(len(policies[CSP_DIRECTIVE_IMAGE]), 1)
-        self.assertEqual(policies[CSP_DIRECTIVE_IMAGE][0], "*")
-        self.assertEqual(len(policies[CSP_DIRECTIVE_CONNECTION]), 1)
-        self.assertEqual(
-            policies[CSP_DIRECTIVE_CONNECTION][0], "trust.sample.com")
-
-    def test_retrieve_csp_policies_with_policies_case04(self):
-        """
-        Test case in which 4 policies are specified using 4 differents CSP
-        headers and in which 1 is specified using report only CSP header.
-        Test in which we want only mandatory policies.
-        """
-        hrds = {}
-        hrds[CSP_HEADER_W3C] = CSP_DIRECTIVE_OBJECT + " 'none'"
-        hrds[CSP_HEADER_FIREFOX] = CSP_DIRECTIVE_IMAGE + " *"
-        hrds[CSP_HEADER_CHROME] = CSP_DIRECTIVE_CONNECTION + \
-            " trust.sample.com"
-        hrds[CSP_HEADER_W3C_REPORT_ONLY] = CSP_DIRECTIVE_SCRIPT + \
-            " report.sample.com"
-        csp_headers = Headers(hrds.items())
-        
-        http_response = HTTPResponse(200, '', csp_headers, self.url, self.url)
-        policies = retrieve_csp_policies(http_response)
-        
-        self.assertEqual(len(policies), 3)
-        self.assertEqual(len(policies[CSP_DIRECTIVE_OBJECT]), 1)
-        self.assertEqual(policies[CSP_DIRECTIVE_OBJECT][0], "none")
-        self.assertEqual(len(policies[CSP_DIRECTIVE_IMAGE]), 1)
-        self.assertEqual(policies[CSP_DIRECTIVE_IMAGE][0], "*")
-        self.assertEqual(len(policies[CSP_DIRECTIVE_CONNECTION]), 1)
-        self.assertEqual(
-            policies[CSP_DIRECTIVE_CONNECTION][0], "trust.sample.com")
-
-    def test_retrieve_csp_policies_with_policies_case05(self):
-        """
-        Test case in which 4 policies are specified using 4 differents CSP
-        headers and in which 1 is specified using report only CSP header.
-        Test in which we want only report-only policies.
-        """
-        hrds = {}
-        hrds[CSP_HEADER_W3C] = CSP_DIRECTIVE_OBJECT + " 'none'"
-        hrds[CSP_HEADER_FIREFOX] = CSP_DIRECTIVE_IMAGE + " *"
-        hrds[CSP_HEADER_CHROME] = CSP_DIRECTIVE_CONNECTION + \
-            " trust.sample.com"
-        hrds[CSP_HEADER_W3C_REPORT_ONLY] = CSP_DIRECTIVE_SCRIPT + \
-            " report.sample.com"
-        csp_headers = Headers(hrds.items())
-        
-        http_response = HTTPResponse(200, '', csp_headers, self.url, self.url)
-        policies = retrieve_csp_policies(http_response, True)
-        
-        self.assertEqual(len(policies), 1)
-        self.assertEqual(len(policies[CSP_DIRECTIVE_SCRIPT]), 1)
-        self.assertEqual(
-            policies[CSP_DIRECTIVE_SCRIPT][0], "report.sample.com")
-        
-    def test_retrieve_csp_policies_with_special_policies_case01(self):
-        """
-        Test case in which 2 policies are specified using special directives
-        with empty value.
-        """
-        header_value = "sandbox ; script-nonce "
-        hrds = {CSP_HEADER_W3C: header_value}.items()
-        csp_headers = Headers(hrds)
-        
-        http_response = HTTPResponse(200, '', csp_headers, self.url, self.url)
-        policies = retrieve_csp_policies(http_response)
-        
-        self.assertEqual(len(policies), 2)
-        self.assertEqual(len(policies[CSP_DIRECTIVE_SANDBOX]), 1)
-        self.assertEqual(policies[CSP_DIRECTIVE_SANDBOX][0], "")
-        self.assertEqual(len(policies[CSP_DIRECTIVE_SCRIPT_NONCE]), 1)        
-        self.assertEqual(policies[CSP_DIRECTIVE_SCRIPT_NONCE][0], "")     
-        
     def test_retrieve_csp_policies_with_special_policies_case02(self):
         """
-        Test case in which 2 policies are specified using special directives
+        Test case in which 2 directives are specified using special directives
         with explicit values.
         """
         header_value = "sandbox allow-forms allow-scripts ;"\
-                       " script-nonce AABBCCDDEE"
-        hrds = {CSP_HEADER_W3C: header_value}.items()
-        csp_headers = Headers(hrds)
-        
-        http_response = HTTPResponse(200, '', csp_headers, self.url, self.url)
-        policies = retrieve_csp_policies(http_response)
-        
-        self.assertEqual(len(policies), 2)
-        self.assertEqual(len(policies[CSP_DIRECTIVE_SANDBOX]), 2)
-        self.assertTrue("allow-forms" in policies[CSP_DIRECTIVE_SANDBOX])
-        self.assertTrue("allow-scripts" in policies[CSP_DIRECTIVE_SANDBOX])
-        self.assertEqual(len(policies[CSP_DIRECTIVE_SCRIPT_NONCE]), 1)        
-        self.assertEqual(policies[CSP_DIRECTIVE_SCRIPT_NONCE][0], "AABBCCDDEE") 
+                       " script-src 'nonce-AABBCCDDEE'"
+        csp = CSPPolicy()
+        csp.init_value(header_value)
+        self.assertEqual(len(csp.directives), 2)
+        d = csp.get_directive_by_name("sandbox")
+        self.assertEqual(len(d.flags), 2)
+        self.assertTrue("allow-forms" in d.flags)
+        self.assertTrue("allow-scripts" in d.flags)
+        d = csp.get_directive_by_name("script-src")
+        self.assertIsNotNone(d)
+        self.assertEqual(d.source_list[0], "'nonce-AABBCCDDEE'") 
         
     def test_find_vulns_case01(self):
         """
         Test case in which we set vulnerables policies using "*" as source  
         for all directives that allow this value.
         """ 
-        header_value = "default-src '*';script-src '*';object-src '*';" \
-                       "style-src '*';img-src '*';media-src '*';" \
-                       "frame-src '*';font-src '*';" \
-                       "form-action '*';connect-src '*';plugin-types '*';"
-        hrds = {CSP_HEADER_W3C: header_value}.items()
-        csp_headers = Headers(hrds)  
-        
-        http_response = HTTPResponse(200, '', csp_headers, self.url, self.url)
-        vulns = find_vulns(http_response)  
-        
-        self.assertEqual(len(vulns), 11)
-        #>>>"default-src"
-        self.assertEqual(len(vulns[CSP_DIRECTIVE_DEFAULT]), 1)
-        self.assertTrue(self._vuln_exists("Directive 'default-src' allows all sources.",
-                        vulns[CSP_DIRECTIVE_DEFAULT]))  
-        #>>>"script-src"
-        self.assertEqual(len(vulns[CSP_DIRECTIVE_SCRIPT]), 2)
-        self.assertTrue(self._vuln_exists("Directive 'script-src' allows all javascript sources.",
-                        vulns[CSP_DIRECTIVE_SCRIPT]))   
-        warn_msg = "Directive 'script-src' is defined but no directive " \
-        "'script-nonce' is defined to protect javascript resources."                                                                                              
-        self.assertTrue(self._vuln_exists(warn_msg, vulns[CSP_DIRECTIVE_SCRIPT]))
-        #>>>"object-src"
-        self.assertEqual(len(vulns[CSP_DIRECTIVE_OBJECT]), 1)
-        self.assertTrue(self._vuln_exists("Directive 'object-src' allows all plugin sources.",
-                        vulns[CSP_DIRECTIVE_OBJECT]))
-        #>>>"style-src"
-        self.assertEqual(len(vulns[CSP_DIRECTIVE_STYLE]), 1)
-        self.assertTrue(self._vuln_exists("Directive 'style-src' allows all CSS sources.",
-                        vulns[CSP_DIRECTIVE_STYLE]))
-        #>>>"img-src"
-        self.assertEqual(len(vulns[CSP_DIRECTIVE_IMAGE]), 1)
-        self.assertTrue(self._vuln_exists("Directive 'img-src' allows all image sources.",
-                        vulns[CSP_DIRECTIVE_IMAGE]))
-        #>>>"media-src"
-        self.assertEqual(len(vulns[CSP_DIRECTIVE_MEDIA]), 1)
-        self.assertTrue(self._vuln_exists("Directive 'media-src' allows all audio/video sources.",
-                        vulns[CSP_DIRECTIVE_MEDIA]))
-        #>>>"frame-src"
-        self.assertEqual(len(vulns[CSP_DIRECTIVE_FRAME]), 2)
-        self.assertTrue(self._vuln_exists("Directive 'frame-src' allows all sources.",
-                        vulns[CSP_DIRECTIVE_FRAME]))
-        warn_msg = "Directive 'frame-src' is defined but no directive " \
-        "'sandbox' is defined to protect resources. Perhaps sandboxing " \
-        "is defined at html attribute level ?"  
-        self.assertTrue(self._vuln_exists(warn_msg, vulns[CSP_DIRECTIVE_FRAME]))              
-        #>>>"font-src"
-        self.assertEqual(len(vulns[CSP_DIRECTIVE_FONT]), 1)
-        self.assertTrue(self._vuln_exists("Directive 'font-src' allows all font sources.",
-                        vulns[CSP_DIRECTIVE_FONT]))
-        #>>>"connect-src"
-        self.assertEqual(len(vulns[CSP_DIRECTIVE_CONNECTION]), 1)
-        self.assertTrue(self._vuln_exists("Directive 'connect-src' allows all connection sources.",
-                        vulns[CSP_DIRECTIVE_CONNECTION]))                                                                                 
-        #>>>"form-action"
-        self.assertEqual(len(vulns[CSP_DIRECTIVE_FORM]), 1)
-        self.assertTrue(self._vuln_exists("Directive 'form-action' allows all action target.",
-                        vulns[CSP_DIRECTIVE_FORM]))
-        #>>>"plugin-types"
-        self.assertEqual(len(vulns[CSP_DIRECTIVE_PLUGIN_TYPES]), 1)
-        self.assertTrue(self._vuln_exists("Directive 'plugin-types' allows all plugins types.",
-                        vulns[CSP_DIRECTIVE_PLUGIN_TYPES]))                      
+        header_value = "default-src *;script-src *;object-src *;" \
+                       "style-src *;img-src *;media-src *;" \
+                       "frame-src *;font-src *;" \
+                       "form-action *;connect-src *;"
+        csp = CSPPolicy()
+        csp.init_value(header_value)
+        vulns = csp.find_vulns()
+        self.assertEqual(len(vulns), 10)
+        vulns = csp.find_vulns_by_directive("default-src")
+        self.assertEqual(len(vulns), 1)
+        vulns = csp.find_vulns_by_directive("script-src")
+        self.assertEqual(len(vulns), 1)
+        vulns = csp.find_vulns_by_directive("object-src")
+        self.assertEqual(len(vulns), 1)
+        vulns = csp.find_vulns_by_directive("style-src")
+        self.assertEqual(len(vulns), 1)
+        vulns = csp.find_vulns_by_directive("img-src")
+        self.assertEqual(len(vulns), 1)
+        vulns = csp.find_vulns_by_directive("media-src")
+        self.assertEqual(len(vulns), 1)
+        vulns = csp.find_vulns_by_directive("frame-src")
+        self.assertEqual(len(vulns), 1)
+        vulns = csp.find_vulns_by_directive("font-src")
+        self.assertEqual(len(vulns), 1)
+        vulns = csp.find_vulns_by_directive("connect-src")
+        self.assertEqual(len(vulns), 1)
+        vulns = csp.find_vulns_by_directive("form-action")
+        self.assertEqual(len(vulns), 1)
 
-    def test_find_vulns_case02(self):
-        """
-        Test case in which we set vulnerables policies for "sandbox",
-        "script-nonce","plugin-types","reflected-xss" directives 
-        using invalid values.
-        """ 
-        header_value = "sandbox allow-invalid; script-nonce aaa,bbb;"\
-        "plugin-types app/titi application/pdf; reflected-xss disallow;"
-        hrds = {CSP_HEADER_W3C: header_value}.items()
-        csp_headers = Headers(hrds)  
-        
-        http_response = HTTPResponse(200, '', csp_headers, self.url, self.url)
-        vulns = find_vulns(http_response)  
-        
-        self.assertEqual(len(vulns), 4)
-        #>>>"sandbox"        
-        self.assertEqual(len(vulns[CSP_DIRECTIVE_SANDBOX]), 1)
-        warn_msg = "Directive 'sandbox' specify invalid value: 'allow-invalid'."
-        self.assertTrue(self._vuln_exists(warn_msg, vulns[CSP_DIRECTIVE_SANDBOX]))
-        #>>>"script-nonce"        
-        self.assertEqual(len(vulns[CSP_DIRECTIVE_SCRIPT_NONCE]), 1)
-        warn_msg = "Directive 'script-nonce' is defined "\
-                   "but nonce contains invalid character (','|';')."
-        self.assertTrue(self._vuln_exists(warn_msg, vulns[CSP_DIRECTIVE_SCRIPT_NONCE]))
-        #>>>"reflected-xss"        
-        self.assertEqual(len(vulns[CSP_DIRECTIVE_XSS]), 1)
-        warn_msg = "Directive 'reflected-xss' specify invalid value: 'disallow'."
-        self.assertTrue(self._vuln_exists(warn_msg, vulns[CSP_DIRECTIVE_XSS]))
-        #>>>"plugins-types"
-        self.assertEqual(len(vulns[CSP_DIRECTIVE_PLUGIN_TYPES]), 1)  
-        warn_msg = "Directive 'plugin-types' specify invalid mime type: 'app/titi'."
-        self.assertTrue(self._vuln_exists(warn_msg, vulns[CSP_DIRECTIVE_PLUGIN_TYPES]))                                                
-        
-        
-    def test_find_vulns_case03(self):
-        """
-        Test case in which we set vulnerables policies for 
-        "sandbox","reflected-xss" directives using valid values.
-        """ 
-        header_value = "sandbox allow-* allow-forms allow-same-origin " \
-                       "allow-scripts allow-top-navigation;"\
-                       "reflected-xss allow;"
-        hrds = {CSP_HEADER_W3C: header_value}.items()
-        csp_headers = Headers(hrds)  
-        
-        http_response = HTTPResponse(200, '', csp_headers, self.url, self.url)
-        vulns = find_vulns(http_response)  
-        
-        self.assertEqual(len(vulns), 2)
-        #>>>"sandbox"        
-        self.assertEqual(len(vulns[CSP_DIRECTIVE_SANDBOX]), 2)
-        warn_msg = "Directive 'sandbox' apply no restrictions."
-        self.assertTrue(vulns[CSP_DIRECTIVE_SANDBOX][0].desc, warn_msg)
-        self.assertTrue(vulns[CSP_DIRECTIVE_SANDBOX][1].desc, warn_msg)    
-        #>>>"reflected-xss"        
-        self.assertEqual(len(vulns[CSP_DIRECTIVE_XSS]), 1)
-        warn_msg = "Directive 'reflected-xss' instruct user agent to "\
-                   "disable its active protections against reflected XSS."
-        self.assertTrue(self._vuln_exists(warn_msg, vulns[CSP_DIRECTIVE_XSS]))  
-        
     def test_find_vulns_case04(self):
         """
         Test case in which we configure correctly policies for all directives.
         """  
-        header_value = "default-src 'self';script-src 'self';object-src 'self';" \
-                       "style-src 'self';img-src 'self';media-src 'self';" \
-                       "frame-src 'self';font-src 'self';sandbox;" \
-                       "form-action '/myCtx/act';connect-src 'self';"\
-                       "plugin-types application/pdf;reflected-xss filter;"\
-                       "script-nonce AABBCCDDEE;"
-        hrds = {CSP_HEADER_W3C: header_value}.items()
-        csp_headers = Headers(hrds)  
-        
-        http_response = HTTPResponse(200, '', csp_headers, self.url, self.url)
-        vulns = find_vulns(http_response)  
+        header_value = "default-src 'self';script-src 'self'; object-src 'self';" \
+                       "style-src 'self'; img-src 'self'; media-src 'self';" \
+                       "frame-src 'self'; font-src 'self'; sandbox;" \
+                       "form-action foo.com/myCtx/act; connect-src 'self';"\
+                       "plugin-types application/pdf;"
+        csp = CSPPolicy()
+        csp.init_value(header_value)
+        vulns = csp.find_vulns()
         self.assertEqual(len(vulns), 0)     
         
     def test_find_vulns_case05(self):
@@ -573,31 +262,19 @@ class TestUtils(unittest.TestCase):
         Test case in which we misspell somes policies.
         """  
         header_value = "defauld-src 'self';script-src 'self';object-src 'self';" \
-                       "style-src 'self';image-src 'self';media-src 'self';" \
-                       "frame-src 'self';font-src 'self';sandbox;" \
-                       "form-src '/myCtx/act';connect-src 'self';"\
-                       "plugin-types application/pdf;reflected-xss filter;"\
-                       "script-nonce AABBCCDDEE;"
-        hrds = {CSP_HEADER_W3C: header_value}.items()
-        csp_headers = Headers(hrds)  
-        
-        http_response = HTTPResponse(200, '', csp_headers, self.url, self.url)
-        vulns = find_vulns(http_response)  
-        self.assertEqual(len(vulns), 1)  
-        self.assertEqual(len(vulns[CSP_MISSPELLED_DIRECTIVES]), 1) 
-        warn_msg = "Some directives are misspelled: "\
-        "defauld-src, image-src, form-src"
-        self.assertTrue(self._vuln_exists(warn_msg, vulns[CSP_MISSPELLED_DIRECTIVES]))
+                       "style-src 'self';image-src 'self';media-src 'self';"
+        csp = CSPPolicy()
+        csp.init_value(header_value)
+        vulns = csp.find_vulns()
+        self.assertEqual(len(vulns), 1)
         
     def test_site_protected_against_xss_by_csp_case01(self):
         """
         Test case in witch site do not provide CSP features.
         """
-        hrds = {}.items()
-        csp_headers = Headers(hrds)          
-        http_response = HTTPResponse(200, '', csp_headers, self.url, self.url)
-        site_protected = site_protected_against_xss_by_csp(http_response)
-        self.assertFalse(site_protected)
+        csp = CSPPolicy()
+        csp.init_value('')
+        self.assertFalse(csp.protects_against_xss())
               
     def test_site_protected_against_xss_by_csp_case02(self):
         """
@@ -605,76 +282,73 @@ class TestUtils(unittest.TestCase):
         on Script policies.
         """
         header_value = "script-src *;"
-        hrds = {CSP_HEADER_W3C: header_value}.items()
-        csp_headers = Headers(hrds)          
-        http_response = HTTPResponse(200, '', csp_headers, self.url, self.url)
-        site_protected = site_protected_against_xss_by_csp(http_response)
-        self.assertFalse(site_protected)
+        csp = CSPPolicy()
+        csp.init_value(header_value)
+        self.assertFalse(csp.protects_against_xss())
         
     def test_site_protected_against_xss_by_csp_case03(self):
         """
-        Test case in witch site provide CSP features and enable unsafe inline
-        script into is CSP Script policies BUT we do not 
-        accept theses configurations.
+        Test case in witch site provides CSP features and enable unsafe inline
+        script into is CSP Script policies. Browsers switches off 'unsafe-inline' 
+        when finds nonses/hashes in sources of script-src
         """
-        header_value = "script-src 'self' unsafe-inline; script-nonce 'AADD'"
-        hrds = {CSP_HEADER_W3C: header_value}.items()
-        csp_headers = Headers(hrds)          
-        http_response = HTTPResponse(200, '', csp_headers, self.url, self.url)
-        site_protected = site_protected_against_xss_by_csp(http_response)
-        self.assertFalse(site_protected) 
-        
+        header_value = "default-src 'self'; script-src 'self' unsafe-inline 'nonce-AADD';"
+        csp = CSPPolicy()
+        csp.init_value(header_value)
+        self.assertTrue(csp.protects_against_xss())
+
     def test_site_protected_against_xss_by_csp_case04(self):
         """
         Test case in witch site provide CSP features and enable use of the
-        javascript "eval()" function into is CSP Script policies BUT we do not 
+        javascript "eval()" function into is CSP Script policies BUT we do 
         accept theses configurations.
         """
-        header_value = "script-src 'self' unsafe-eval; script-nonce 'AADD'"
-        hrds = {CSP_HEADER_W3C: header_value}.items()
-        csp_headers = Headers(hrds)          
-        http_response = HTTPResponse(200, '', csp_headers, self.url, self.url)
-        site_protected = site_protected_against_xss_by_csp(http_response)
-        self.assertFalse(site_protected)   
+        header_value = "default-src 'self'; script-src 'self' 'unsafe-eval' 'nonce-AADD'"
+        csp = CSPPolicy()
+        csp.init_value(header_value)
+        self.assertTrue(csp.protects_against_xss())
         
-    def test_site_protected_against_xss_by_csp_case05(self):
-        """
-        Test case in witch site provide CSP features and enable unsafe inline
-        script + use of the javascript "eval()" function into is CSP Script 
-        policies BUT we accept theses configurations.
-        """
-        header_value = "script-src 'self' unsafe-eval unsafe-inline; "\
-                       "script-nonce 'AADD'"
-        hrds = {CSP_HEADER_W3C: header_value}.items()
-        csp_headers = Headers(hrds)          
-        http_response = HTTPResponse(200, '', csp_headers, self.url, self.url)
-        site_protected = site_protected_against_xss_by_csp(http_response,
-                                                           True,
-                                                           True)
-        self.assertTrue(site_protected)                                        
-
     def test_site_protected_against_xss_by_csp_case06(self):
         """
         Test case in witch site is secure
         """
         header_value = "default-src 'self'"
-        hrds = {CSP_HEADER_W3C: header_value}.items()
-        csp_headers = Headers(hrds)          
-        http_response = HTTPResponse(200, '', csp_headers, self.url, self.url)
-        site_protected = site_protected_against_xss_by_csp(http_response)
-        self.assertTrue(site_protected)
-        
-    def _vuln_exists(self, vuln_desc, vulns_list):
+        csp = CSPPolicy()
+        csp.init_value(header_value)
+        self.assertTrue(csp.protects_against_xss())
+
+
+    def test_site_protected_against_xss_by_csp_case07(self):
         """
-        Internal method to check if a vuln is present into a vulns list
-        coming from method "find_vulns()".
-        
-        :param vuln_desc: Vuln description.
-        :param vulns_list: vulns list coming from method "find_vulns()".
-        :return: True only if vuln is found. 
-        """        
-        for v in vulns_list:
-            if v.desc == vuln_desc:
-                return True
-        
-        return False
+        Test case in we check for protects_against_xss() high level CSP object
+        """
+        header_value = "default-src 'self'; script-src 'self' trust.com;"
+        headers = Headers({'Content-Security-Policy': header_value}.items())
+        http_response = HTTPResponse(200, '', headers, self.url, self.url)
+        csp = CSP()
+        csp.init_from_response(http_response)
+        self.assertTrue(csp.protects_against_xss())
+ 
+    def test_retrieve_csp_policies_from_meta(self):
+        """
+        Test case in which no policies are specified into HTTP response.
+        """
+        html_data =  """<html><head>
+        <meta http-equiv="Content-Security-Policy" content="script-src 'self'">
+        </head><body></body></html>"""
+        headers = Headers({'Content-Type':'text/html; charset=UTF-8'}.items())
+        http_response = HTTPResponse(200, html_data, headers, self.url, self.url)
+        csp = CSP()
+        csp.init_from_response(http_response)
+        self.assertEqual(len(csp.policies), 1)
+
+    def test_find_vulns_untrusted(self):
+        """
+        Test case in which we add untrusted hosts into somes policies.
+        """  
+        header_value = "default-src 'self'; script-src 'self' trust.com evil.com;"
+        csp = CSPPolicy()
+        csp.trusted_hosts = ['trust.com']
+        csp.init_value(header_value)
+        vulns = csp.find_vulns()
+        self.assertEqual(len(vulns), 1)

--- a/w3af/core/controllers/csp/tests/test_csp_utils.py
+++ b/w3af/core/controllers/csp/tests/test_csp_utils.py
@@ -27,6 +27,7 @@ from w3af.core.data.parsers.doc.url import URL
 from w3af.core.data.dc.headers import Headers
 from w3af.core.controllers.csp.utils import CSP, CSPPolicy
 
+
 class TestUtils(unittest.TestCase):
     header = 'Content-Security-Policy'
     header_report_only = 'Content-Security-Policy-Report-Only'
@@ -60,7 +61,7 @@ class TestUtils(unittest.TestCase):
         Test case in which site provides "unsafe-inline" related CSP for
         script.
         """
-        csp_value =  "script-src 'unsafe-inline'"
+        csp_value = "script-src 'unsafe-inline'"
         csp = CSPPolicy()
         csp.init_value(csp_value)
         self.assertTrue(csp.unsafe_inline_enabled())
@@ -70,7 +71,7 @@ class TestUtils(unittest.TestCase):
         Test case in which site provides "unsafe-inline" related CSP for
         Style.
         """
-        csp_value =  "style-src 'unsafe-inline'"
+        csp_value = "style-src 'unsafe-inline'"
         csp = CSPPolicy()
         csp.init_value(csp_value)
         self.assertTrue(csp.unsafe_inline_enabled())
@@ -88,7 +89,7 @@ class TestUtils(unittest.TestCase):
         """
         Test case in which site provides CSP report uri.
         """
-        csp_value =  "default-src 'self'; report-uri foo.com/myrelativeuri"
+        csp_value = "default-src 'self'; report-uri foo.com/myrelativeuri"
         csp = CSPPolicy()
         csp.init_value(csp_value)
         uri_set = csp.get_report_uri()
@@ -96,7 +97,8 @@ class TestUtils(unittest.TestCase):
 
     def test_report_no_report_uri(self):
         """
-        Test case in which site do not provides CSP report uri and we need to know about it.
+        Test case in which site do not provides CSP report uri
+ and we need to know about it.
         """
         csp_value = "default-src 'self';"
         csp = CSPPolicy()
@@ -127,10 +129,12 @@ class TestUtils(unittest.TestCase):
         """
         Test case in which site provides broken CSP 2.
         """
-        header_value = "default-src ' '; img-src ' '"
+        header_value = "default-src 'none'; img-src aaa'bbb"
         csp = CSPPolicy()
-        self.assertFalse(csp.init_value(header_value))
-        
+        csp.init_value(header_value)
+        vulns = csp.find_vulns()
+        self.assertEqual(len(vulns), 1)
+ 
     def test_provides_csp_features_yes_case01(self):
         """
         Test case in which site provides CSP features using only mandatory
@@ -153,7 +157,8 @@ class TestUtils(unittest.TestCase):
                        " *.cdn.example.com; script-src"\
                        " trustedscripts.example.com"
         csp = CSPPolicy()
-        self.assertTrue(csp.init_from_header('Content-Security-Policy-Report-Only', header_value))
+        self.assertTrue(csp.init_from_header(
+            'Content-Security-Policy-Report-Only', header_value))
 
     def test_retrieve_csp_policies_without_policies(self):
         """
@@ -216,13 +221,13 @@ class TestUtils(unittest.TestCase):
         self.assertTrue("allow-scripts" in d.flags)
         d = csp.get_directive_by_name("script-src")
         self.assertIsNotNone(d)
-        self.assertEqual(d.source_list[0], "'nonce-AABBCCDDEE'") 
+        self.assertEqual(d.source_list[0], "'nonce-AABBCCDDEE'")
         
     def test_find_vulns_case01(self):
         """
-        Test case in which we set vulnerables policies using "*" as source  
-        for all directives that allow this value.
-        """ 
+        Test case in which we set vulnerables policies using "*" as source
+ for all directives that allow this value.
+        """
         header_value = "default-src *;script-src *;object-src *;" \
                        "style-src *;img-src *;media-src *;" \
                        "frame-src *;font-src *;" \
@@ -255,7 +260,7 @@ class TestUtils(unittest.TestCase):
     def test_find_vulns_case04(self):
         """
         Test case in which we configure correctly policies for all directives.
-        """  
+        """
         header_value = "default-src 'self';script-src 'self'; object-src 'self';" \
                        "style-src 'self'; img-src 'self'; media-src 'self';" \
                        "frame-src 'self'; font-src 'self'; sandbox;" \
@@ -270,12 +275,12 @@ class TestUtils(unittest.TestCase):
         """
         Test case in which we misspell somes policies.
         """  
-        header_value = "defauld-src 'self';script-src 'self';object-src 'self';" \
+        header_value = "default-src 'self'; scrip-src 'self';object-src 'self';" \
                        "style-src 'self';image-src 'self';media-src 'self';"
         csp = CSPPolicy()
         csp.init_value(header_value)
         vulns = csp.find_vulns()
-        self.assertEqual(len(vulns), 1)
+        self.assertEqual(len(vulns), 2)
         
     def test_site_protected_against_xss_by_csp_case01(self):
         """
@@ -298,8 +303,8 @@ class TestUtils(unittest.TestCase):
     def test_site_protected_against_xss_by_csp_case03(self):
         """
         Test case in witch site provides CSP features and enable unsafe inline
-        script into is CSP Script policies. Browsers switches off 'unsafe-inline' 
-        when finds nonses/hashes in sources of script-src
+        script into is CSP Script policies. Browsers switches off 
+        'unsafe-inline' when finds nonses/hashes in sources of script-src
         """
         header_value = "default-src 'self'; script-src 'self' unsafe-inline 'nonce-AADD';"
         csp = CSPPolicy()
@@ -359,7 +364,6 @@ class TestUtils(unittest.TestCase):
         csp.init_value(header_value)
         self.assertTrue(csp.protects_against_xss())
 
-
     def test_site_protected_against_xss_by_csp_case07(self):
         """
         Test case in we check for protects_against_xss() high level CSP object
@@ -375,10 +379,10 @@ class TestUtils(unittest.TestCase):
         """
         Test case in which no policies are specified into HTTP response.
         """
-        html_data =  """<html><head>
+        html_data = """<html><head>
         <meta http-equiv="Content-Security-Policy" content="script-src 'self'">
         </head><body></body></html>"""
-        headers = Headers({'Content-Type':'text/html; charset=UTF-8'}.items())
+        headers = Headers({'Content-Type': 'text/html; charset=UTF-8'}.items())
         http_response = HTTPResponse(200, html_data, headers, self.url, self.url)
         csp = CSP()
         csp.init_from_response(http_response)
@@ -429,7 +433,7 @@ class TestUtils(unittest.TestCase):
         """
         Test case in which we set strictness level for default-src 0 (all sources permitted).
         """  
-        header_value = "default-src 'self' foo.com;"
+        header_value = "default-src 'self' foo.com; form-action foobar.com; frame-ancestors 'none';"
         csp = CSPPolicy()
         csp.default_src_strictness = 0
         csp.init_value(header_value)
@@ -440,7 +444,7 @@ class TestUtils(unittest.TestCase):
         """
         Test case in which we set strictness level for default-src 1 (only 'self').
         """  
-        header_value = "default-src 'self' foo.com;"
+        header_value = "default-src 'self' foo.com; form-action foobar.com; frame-ancestors 'none';"
         csp = CSPPolicy()
         csp.default_src_strictness = 1
         csp.init_value(header_value)
@@ -451,9 +455,30 @@ class TestUtils(unittest.TestCase):
         """
         Test case in which we set strictness level for default-src 2 (only 'none').
         """  
-        header_value = "default-src 'self';"
+        header_value = "default-src 'self'; form-action foobar.com; frame-ancestors 'none';"
         csp = CSPPolicy()
         csp.default_src_strictness = 2
+        csp.init_value(header_value)
+        vulns = csp.find_vulns()
+        self.assertEqual(len(vulns), 1)
+
+    def test_not_fallback_directives(self):
+        """
+        Test case in which we test required directives (form-action, frame-ancestors, base-uri).
+        """  
+        header_value = "default-src 'self';"
+        csp = CSPPolicy()
+        csp.report_not_fallback = True
+        csp.init_value(header_value)
+        vulns = csp.find_vulns()
+        self.assertEqual(len(vulns), 3)
+
+    def test_with_absent_default(self):
+        """
+        Test case in which we test scenario with default-src not explicitly set.
+        """  
+        header_value = "script-src 'self';"
+        csp = CSPPolicy()
         csp.init_value(header_value)
         vulns = csp.find_vulns()
         self.assertEqual(len(vulns), 1)

--- a/w3af/core/controllers/csp/tests/test_csp_utils.py
+++ b/w3af/core/controllers/csp/tests/test_csp_utils.py
@@ -94,6 +94,17 @@ class TestUtils(unittest.TestCase):
         uri_set = csp.get_report_uri()
         self.assertEqual("foo.com/myrelativeuri", uri_set)
 
+    def test_report_no_report_uri(self):
+        """
+        Test case in which site do not provides CSP report uri and we need to know about it.
+        """
+        csp_value = "default-src 'self';"
+        csp = CSPPolicy()
+        csp.report_no_report_uri = True
+        csp.init_value(csp_value)
+        vulns = csp.find_vulns()
+        self.assertEqual(len(vulns), 1)
+
     def test_provides_csp_features_no_case01(self):
         """
         Test case in which site do not provides CSP features.
@@ -306,6 +317,18 @@ class TestUtils(unittest.TestCase):
         csp = CSPPolicy()
         csp.init_value(header_value)
         self.assertTrue(csp.protects_against_xss())
+
+    def test_not_report_eval(self):
+        """
+        Test case in witch site provide CSP features and enable use of the
+        javascript "eval()" function into is CSP Script policies AND we DON'T want to know about it.
+        """
+        header_value = "default-src 'self'; script-src 'self' 'unsafe-eval'"
+        csp = CSPPolicy()
+        csp.report_eval = False
+        csp.init_value(header_value)
+        vulns = csp.find_vulns()
+        self.assertEqual(len(vulns), 0)
         
     def test_site_protected_against_xss_by_csp_case06(self):
         """

--- a/w3af/core/controllers/csp/tests/test_csp_utils.py
+++ b/w3af/core/controllers/csp/tests/test_csp_utils.py
@@ -424,3 +424,36 @@ class TestUtils(unittest.TestCase):
         d = csp.get_directive_by_name("script-src")
         self.assertIsNotNone(d)
         self.assertEqual(len(d.source_list), 2) 
+
+    def test_strict_default0(self):
+        """
+        Test case in which we set strictness level for default-src 0 (all sources permitted).
+        """  
+        header_value = "default-src 'self' foo.com;"
+        csp = CSPPolicy()
+        csp.default_src_strictness = 0
+        csp.init_value(header_value)
+        vulns = csp.find_vulns()
+        self.assertEqual(len(vulns), 0)
+
+    def test_strict_default1(self):
+        """
+        Test case in which we set strictness level for default-src 1 (only 'self').
+        """  
+        header_value = "default-src 'self' foo.com;"
+        csp = CSPPolicy()
+        csp.default_src_strictness = 1
+        csp.init_value(header_value)
+        vulns = csp.find_vulns()
+        self.assertEqual(len(vulns), 1)
+
+    def test_strict_default2(self):
+        """
+        Test case in which we set strictness level for default-src 2 (only 'none').
+        """  
+        header_value = "default-src 'self';"
+        csp = CSPPolicy()
+        csp.default_src_strictness = 2
+        csp.init_value(header_value)
+        vulns = csp.find_vulns()
+        self.assertEqual(len(vulns), 1)

--- a/w3af/core/controllers/csp/tests/test_csp_utils.py
+++ b/w3af/core/controllers/csp/tests/test_csp_utils.py
@@ -118,7 +118,6 @@ class TestUtils(unittest.TestCase):
         """
         header_value = "default-src ' '; img-src ' '"
         csp = CSPPolicy()
-        print csp.init_value(header_value), csp.directives
         self.assertFalse(csp.init_value(header_value))
         
     def test_provides_csp_features_yes_case01(self):

--- a/w3af/core/controllers/csp/tests/test_csp_utils.py
+++ b/w3af/core/controllers/csp/tests/test_csp_utils.py
@@ -318,6 +318,27 @@ class TestUtils(unittest.TestCase):
         csp.init_value(header_value)
         self.assertTrue(csp.protects_against_xss())
 
+    def test_site_protected_against_xss_by_csp_case05(self):
+        """
+        Test case in witch site provide CSP features and have a vuln 
+        on Script policies (data:).
+        """
+        header_value = "script-src data:"
+        csp = CSPPolicy()
+        csp.init_value(header_value)
+        self.assertFalse(csp.protects_against_xss())
+
+    def test_report_eval(self):
+        """
+        Test case in witch site provide CSP features and enable use of the
+        javascript "eval()" function into is CSP Script policies AND we want to report it.
+        """
+        header_value = "default-src 'self' blob:; script-src 'self' 'unsafe-eval'"
+        csp = CSPPolicy()
+        csp.init_value(header_value)
+        vulns = csp.find_vulns()
+        self.assertEqual(len(vulns), 2)
+        
     def test_not_report_eval(self):
         """
         Test case in witch site provide CSP features and enable use of the
@@ -368,7 +389,7 @@ class TestUtils(unittest.TestCase):
         """
         Test case in which we add untrusted hosts into somes policies.
         """  
-        header_value = "default-src 'self'; script-src blob: data: 'self' trust.com evil.com;"
+        header_value = "default-src 'self'; script-src 'self' trust.com evil.com;"
         csp = CSPPolicy()
         csp.trusted_hosts = ['trust.com']
         csp.init_value(header_value)

--- a/w3af/core/controllers/csp/utils.py
+++ b/w3af/core/controllers/csp/utils.py
@@ -135,11 +135,11 @@ to the default sources when the directive is not defined."""
         if token in ["'self'", "'unsafe-inline'", "'unsafe-eval'"]:
             return True
         # nonce-source
-        p = re.compile("'nonce-[a-zA-Z0-9=]+'")
+        p = re.compile("'nonce-[a-zA-Z0-9+/]+[=]{0,2}'")
         if p.match(token):
             return True
         # hash-source
-        p = re.compile("'(sha256|sha384|sha512)-[a-zA-Z0-9=]+'")
+        p = re.compile("'(sha256|sha384|sha512)-[a-zA-Z0-9+/]+[=]{0,2}'")
         if p.match(token):
             return True
         # scheme-source 

--- a/w3af/core/controllers/csp/utils.py
+++ b/w3af/core/controllers/csp/utils.py
@@ -231,7 +231,7 @@ class CSPDirective(object):
                     untrusted.append(source)
         
         if untrusted:
-            vuln = CSPVulnerability(self.vuln_untrust_tpl % (self.name, ",".join(untrusted)), 
+            vuln = CSPVulnerability(self.vuln_untrust_tpl % (self.name, ", ".join(untrusted)), 
                     severity.LOW, 'untrust', self.name)
             vulns_lst = [vuln]
         return vulns_lst

--- a/w3af/core/controllers/csp/utils.py
+++ b/w3af/core/controllers/csp/utils.py
@@ -18,58 +18,13 @@ You should have received a copy of the GNU General Public License
 along with w3af; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 """
+import re
+from urlparse import urlparse
 from mimetypes import MimeTypes
 from collections import namedtuple
 import w3af.core.data.constants.severity as severity
-
-
-#Keys representing CSP headers for manipulations 
-#(values from W3C Specs).
-CSP_HEADER_W3C = "Content-Security-Policy"
-CSP_HEADER_FIREFOX = "X-Content-Security-Policy"
-CSP_HEADER_CHROME = "X-WebKit-CSP"
-CSP_HEADER_IE = "X-Content-Security-Policy"
-CSP_HEADER_W3C_REPORT_ONLY = "Content-Security-Policy-Report-Only"
-
-#Keys representing CSP directives names for manipulations 
-#(values from W3C Specs).
-CSP_DIRECTIVE_DEFAULT = "default-src"
-CSP_DIRECTIVE_SCRIPT = "script-src"
-CSP_DIRECTIVE_OBJECT = "object-src"
-CSP_DIRECTIVE_STYLE = "style-src"
-CSP_DIRECTIVE_IMAGE = "img-src"
-CSP_DIRECTIVE_MEDIA = "media-src"
-CSP_DIRECTIVE_FRAME = "frame-src"
-CSP_DIRECTIVE_FONT = "font-src"
-CSP_DIRECTIVE_CONNECTION = "connect-src"
-CSP_DIRECTIVE_REPORT_URI = "report-uri"
-CSP_DIRECTIVE_FORM = "form-action"
-CSP_DIRECTIVE_SANDBOX = "sandbox"
-CSP_DIRECTIVE_SCRIPT_NONCE = "script-nonce"
-CSP_DIRECTIVE_PLUGIN_TYPES = "plugin-types"
-CSP_DIRECTIVE_XSS = "reflected-xss"
-
-#Keys representing key used to store misspelled directives name 
-#in extraction dictionary
-CSP_MISSPELLED_DIRECTIVES = "misspelled-directives-name"
-
-#Keys representing CSP directives values for manipulations 
-#(values from W3C Specs).
-CSP_DIRECTIVE_VALUE_UNSAFE_INLINE = "unsafe-inline"
-CSP_DIRECTIVE_VALUE_UNSAFE_EVAL = "unsafe-eval"
-CSP_DIRECTIVE_VALUE_ALLOW_FORMS = "allow-forms"
-CSP_DIRECTIVE_VALUE_ALLOW_SAME_ORIGIN = "allow-same-origin"
-CSP_DIRECTIVE_VALUE_ALLOW_SCRIPTS = "allow-scripts"
-CSP_DIRECTIVE_VALUE_ALLOW_TOP_NAV = "allow-top-navigation"
-CSP_DIRECTIVE_VALUE_XSS_BLOCK = "block"
-CSP_DIRECTIVE_VALUE_XSS_ALLOW = "allow"
-CSP_DIRECTIVE_VALUE_XSS_FILTER = "filter"
-
-#Note:
-#Special directive refer to directive for which empty value specify a
-#behavior, on W3C CSP Specs v1.1 theses directives are: 
-# -> sandbox
-# -> script-nonce
+from w3af.core.controllers.exceptions import BaseFrameworkException
+import w3af.core.data.parsers.parser_cache as parser_cache
 
 #Valid Mime Types list
 MIME_TYPES = MimeTypes().types_map[1].values()
@@ -78,535 +33,742 @@ MIME_TYPES = MimeTypes().types_map[1].values()
 #Declare type here in order to expose it with project visibility
 #and permit cPickle processing to see it. See link below:
 #http://stackoverflow.com/questions/4677012/python-cant-pickle-type-x-attribute-lookup-failed
-CSPVulnerability = namedtuple('CSPVulnerability', ['desc', 'severity'])            
+CSPVulnerability = namedtuple('CSPVulnerability', ['desc', 'severity', 'type', 'directive'])            
 
-
-def site_protected_against_xss_by_csp(response, allow_unsafe_inline=False,
-                                      allow_unsafe_eval=False):
+class CSPDirective(object):
     """
-    Method to analyze if a site is protected against XSS vulns type using
-    CSP policies.
-    
-    :param response: A HTTPResponse object.
-    :param allow_unsafe_eval: Allow inline javascript code block.
-    :param allow_unsafe_eval: Allow use of the java "eval()" function in
-                              javascript code block.  
-    :return: True only if the site is protected, False otherwise.  
+    Represents CSP directive.
     """
-    protected = True
-    
-    if not provides_csp_features(response):
-        protected = False
-    else:
-        #Try to find vulns on CSP policies related to Script 
-        vulns = find_vulns(response)
-        if CSP_DIRECTIVE_SCRIPT in vulns:            
-            protected = False
-        else:
-            #Check Script dedicated directive value for
-            #- inline javascript code block
-            #- "eval()" javascript function
-            if not allow_unsafe_inline and unsafe_inline_enabled(response):
-                protected = False
-            if not allow_unsafe_eval and unsafe_eval_enabled(response):
-                protected = False
-    
-    return protected
+    name = "CSPDirective"
+    value = ""
+    source_list = []
+    _source_limit = None
 
+    vuln_wildcard_tpl = "Directive '%s' allows all sources."
+    vuln_inline_tpl = "Directive '%s' allows unsafe-inline. Use nonces or hashes."
+    vuln_eval_tpl = "Directive '%s' allows unsafe-eval."
+    vuln_untrust_tpl = "Directive '%s' consists of untrusted sources: %s."
+    vuln_source_limit_tpl = "Directive '%s' consists of too many sources in source list."
+    vuln_required_tpl = """Directive '%s' is not defined. NB! It does not fall back 
+    to the default sources when the directive is not defined."""
 
-def find_vulns(response):
-    """
-    Method to find vulnerabilities into CSP policies from an HTTP response,
-    analyze directives for permissive/invalid configuration and misspelled
-    directive names.
+    def __init__(self, name=None):
+        if name:
+            self.name = name
     
-    :param response: A HTTPResponse object.
-    :return: A dictionary in which KEY is a CSP directive and VALUE is the 
-             list of vulnerabilities found for the associated directive.
-             A vulnerability is represented as NamedTuple exposing properties
-             "desc" and "severity", both as String data type.
-             Access example: vulns[CSP_DIRECTIVE_DEFAULT][0].desc
-    """
-    vulns = {}
-    
-    ##Extract and merge all policies
-    non_report_only_policies = retrieve_csp_policies(response, False, True)
-    report_only_policies = retrieve_csp_policies(response, True, True)
-    policies_all = merge_policies_dict(non_report_only_policies, report_only_policies)
-    
-    #Quick exit to enhance performance
-    if len(policies_all) == 0:
-        return vulns
-        
-    #Analyze each policy in details. 
-    ##Code analyse each directive independently in order to prepare algorithm to
-    ##be enhanced with CSP specs evolution !
-    ####Directive "default-src"
-    if CSP_DIRECTIVE_DEFAULT in policies_all:        
-        directive_values = policies_all[CSP_DIRECTIVE_DEFAULT]
-        if "*" in directive_values:
-            csp_vuln = CSPVulnerability("Directive 'default-src' allows all sources.",
-                                        severity.HIGH)
-            vulns_lst = [csp_vuln]
-            vulns[CSP_DIRECTIVE_DEFAULT] = vulns_lst
-    ####Directive "script-src"
-    if CSP_DIRECTIVE_SCRIPT in policies_all:        
-        directive_values = policies_all[CSP_DIRECTIVE_SCRIPT]
-        vulns_lst = []
-        warn_msg = ""        
-        #We do not check for 'unsafe-inline' and 'unsafe-eval' values because:
-        #=>Many site use inline javascript code block
-        #=>Some popular javascript API (ex: JQueryUI/ExtJS) use eval() function 
-        if "*" in directive_values:
-            warn_msg = "Directive 'script-src' allows all javascript sources."
-            csp_vuln = CSPVulnerability(warn_msg, severity.HIGH)            
-            vulns_lst.append(csp_vuln)   
-        if CSP_DIRECTIVE_SCRIPT_NONCE not in policies_all:
-            warn_msg = ("Directive 'script-src' is defined but no directive"
-                        " 'script-nonce' is defined to protect javascript"
-                        " resources.")
-            csp_vuln = CSPVulnerability(warn_msg, severity.HIGH)            
-            vulns_lst.append(csp_vuln)                
-        if len(vulns_lst) > 0:
-            vulns[CSP_DIRECTIVE_SCRIPT] = vulns_lst            
-    ####Directive "object-src"
-    if CSP_DIRECTIVE_OBJECT in policies_all:        
-        directive_values = policies_all[CSP_DIRECTIVE_OBJECT]
-        if "*" in directive_values:
-            csp_vuln = CSPVulnerability("Directive 'object-src' allows all plugin sources.",
-                                        severity.HIGH)            
-            vulns_lst = [csp_vuln]
-            vulns[CSP_DIRECTIVE_OBJECT] = vulns_lst
-    ####Directive "style-src"
-    if CSP_DIRECTIVE_STYLE in policies_all:        
-        directive_values = policies_all[CSP_DIRECTIVE_STYLE]
-        if "*" in directive_values:
-            csp_vuln = CSPVulnerability("Directive 'style-src' allows all CSS sources.",
-                                        severity.LOW)            
-            vulns_lst = [csp_vuln]
-            vulns[CSP_DIRECTIVE_STYLE] = vulns_lst
-    ####Directive "img-src"
-    if CSP_DIRECTIVE_IMAGE in policies_all:        
-        directive_values = policies_all[CSP_DIRECTIVE_IMAGE]
-        if "*" in directive_values:
-            csp_vuln = CSPVulnerability("Directive 'img-src' allows all image sources.",
-                                        severity.LOW)               
-            vulns_lst = [csp_vuln]
-            vulns[CSP_DIRECTIVE_IMAGE] = vulns_lst
-    ####Directive "media-src"
-    if CSP_DIRECTIVE_MEDIA in policies_all:        
-        directive_values = policies_all[CSP_DIRECTIVE_MEDIA]
-        if "*" in directive_values:
-            csp_vuln = CSPVulnerability("Directive 'media-src' allows all audio/video sources.",
-                                        severity.HIGH)            
-            vulns_lst = [csp_vuln]
-            vulns[CSP_DIRECTIVE_MEDIA] = vulns_lst
-    ####Directive "frame-src"
-    if CSP_DIRECTIVE_FRAME in policies_all:        
-        directive_values = policies_all[CSP_DIRECTIVE_FRAME]
-        vulns_lst = []
-        warn_msg = ""
-        if "*" in directive_values:
-            csp_vuln = CSPVulnerability("Directive 'frame-src' allows all sources.",
-                                        severity.HIGH)            
-            vulns_lst.append(csp_vuln)
-        if CSP_DIRECTIVE_SANDBOX not in policies_all:
-            warn_msg = "Directive 'frame-src' is defined but no directive " \
-            "'sandbox' is defined to protect resources. Perhaps sandboxing " \
-            "is defined at html attribute level ?"
-            csp_vuln = CSPVulnerability(warn_msg, severity.HIGH)            
-            vulns_lst.append(csp_vuln)                
-        if len(vulns_lst) > 0:
-            vulns[CSP_DIRECTIVE_FRAME] = vulns_lst
-    ####Directive "font-src"
-    if CSP_DIRECTIVE_FONT in policies_all:        
-        directive_values = policies_all[CSP_DIRECTIVE_FONT]
-        if "*" in directive_values:
-            csp_vuln = CSPVulnerability("Directive 'font-src' allows all font sources.",
-                                        severity.MEDIUM)               
-            vulns_lst = [csp_vuln]            
-            vulns[CSP_DIRECTIVE_FONT] = vulns_lst
-    ####Directive "connect-src"
-    if CSP_DIRECTIVE_CONNECTION in policies_all:        
-        directive_values = policies_all[CSP_DIRECTIVE_CONNECTION]
-        if "*" in directive_values:
-            csp_vuln = CSPVulnerability("Directive 'connect-src' allows all connection sources.",
-                                        severity.HIGH)               
-            vulns_lst = [csp_vuln]                        
-            vulns[CSP_DIRECTIVE_CONNECTION] = vulns_lst
-    ####Directive "form-action"
-    if CSP_DIRECTIVE_FORM in policies_all:        
-        directive_values = policies_all[CSP_DIRECTIVE_FORM]
-        if "*" in directive_values:
-            csp_vuln = CSPVulnerability("Directive 'form-action' allows all action target.",
-                                        severity.HIGH)               
-            vulns_lst = [csp_vuln]                                    
-            vulns[CSP_DIRECTIVE_FORM] = vulns_lst  
-    ####Directive "sandbox"
-    if CSP_DIRECTIVE_SANDBOX in policies_all:        
-        directive_values = policies_all[CSP_DIRECTIVE_SANDBOX]
-        warn_msg = ""
-        vulns_lst = []
-        if "allow-*" in directive_values:
-            csp_vuln = CSPVulnerability("Directive 'sandbox' apply no restrictions.",
-                                        severity.HIGH)            
-            vulns_lst.append(csp_vuln)
-        if (CSP_DIRECTIVE_VALUE_ALLOW_FORMS in directive_values and
-            CSP_DIRECTIVE_VALUE_ALLOW_SAME_ORIGIN in directive_values and
-            CSP_DIRECTIVE_VALUE_ALLOW_SCRIPTS in directive_values and
-            CSP_DIRECTIVE_VALUE_ALLOW_TOP_NAV in directive_values):
-            csp_vuln = CSPVulnerability("Directive 'sandbox' apply no restrictions.",
-                                        severity.HIGH)            
-            vulns_lst.append(csp_vuln) 
-        #Search invalid directive values
-        valid_values = []
-        valid_values.append("")
-        valid_values.append("allow-*")
-        valid_values.append(CSP_DIRECTIVE_VALUE_ALLOW_FORMS)
-        valid_values.append(CSP_DIRECTIVE_VALUE_ALLOW_SAME_ORIGIN)
-        valid_values.append(CSP_DIRECTIVE_VALUE_ALLOW_SCRIPTS)
-        valid_values.append(CSP_DIRECTIVE_VALUE_ALLOW_TOP_NAV)
-        for value in directive_values:
-            if value not in valid_values:
-                warn_msg = "Directive 'sandbox' specify invalid value: "\
-                "'" + value + "'."
-                csp_vuln = CSPVulnerability(warn_msg, severity.HIGH)            
-                vulns_lst.append(csp_vuln)                
-        if len(vulns_lst) > 0:
-            vulns[CSP_DIRECTIVE_SANDBOX] = vulns_lst                     
-    ####Directive "script-nonce"
-    if CSP_DIRECTIVE_SCRIPT_NONCE in policies_all:        
-        directive_values = policies_all[CSP_DIRECTIVE_SCRIPT_NONCE]
-        warn_msg = ""
-        vulns_lst = []        
-        #Search invalid directive values
-        for nonce in directive_values:            
-            if len(nonce.strip()) == 0:
-                warn_msg = "Directive 'script-nonce' is defined "\
-                           "but nonce is empty."
-                csp_vuln = CSPVulnerability(warn_msg, severity.HIGH)            
-                vulns_lst.append(csp_vuln)
-            elif nonce.count(",") > 0 or nonce.count(";") > 0:
-                warn_msg = "Directive 'script-nonce' is defined "\
-                           "but nonce contains invalid character (','|';')."
-                csp_vuln = CSPVulnerability(warn_msg, severity.HIGH)            
-                vulns_lst.append(csp_vuln)                                             
-        if len(vulns_lst) > 0:
-            vulns[CSP_DIRECTIVE_SCRIPT_NONCE] = vulns_lst                 
-    ####Directive "plugin-types"
-    if CSP_DIRECTIVE_PLUGIN_TYPES in policies_all:        
-        directive_values = policies_all[CSP_DIRECTIVE_PLUGIN_TYPES]
-        warn_msg = ""
-        vulns_lst = []        
-        if "*" in directive_values:
-            warn_msg = "Directive 'plugin-types' allows all plugins types."
-            csp_vuln = CSPVulnerability(warn_msg, severity.HIGH)            
-            vulns_lst.append(csp_vuln)            
-        #Search invalid directive values
-        for mtype in directive_values:
-            if mtype != "*" and mtype.lower() not in MIME_TYPES:
-                warn_msg = "Directive 'plugin-types' specify invalid mime " \
-                           "type: '" + mtype + "'."
-                csp_vuln = CSPVulnerability(warn_msg, severity.HIGH)            
-                vulns_lst.append(csp_vuln)              
-        if len(vulns_lst) > 0:
-            vulns[CSP_DIRECTIVE_PLUGIN_TYPES] = vulns_lst                
-    ####Directive "reflected-xss"
-    if CSP_DIRECTIVE_XSS in policies_all:        
-        directive_values = policies_all[CSP_DIRECTIVE_XSS]
-        warn_msg = ""
-        vulns_lst = []
-        if CSP_DIRECTIVE_VALUE_XSS_ALLOW in directive_values:
-            warn_msg = "Directive 'reflected-xss' instruct user agent to "\
-                       "disable its active protections against reflected XSS."
-            csp_vuln = CSPVulnerability(warn_msg, severity.HIGH)            
-            vulns_lst.append(csp_vuln) 
-        #Search invalid directive values
-        valid_values = []
-        valid_values.append(CSP_DIRECTIVE_VALUE_XSS_ALLOW)
-        valid_values.append(CSP_DIRECTIVE_VALUE_XSS_BLOCK)
-        valid_values.append(CSP_DIRECTIVE_VALUE_XSS_FILTER)
-        for value in directive_values:
-            if value not in valid_values:
-                warn_msg = "Directive 'reflected-xss' specify invalid value: "\
-                "'" + value + "'."
-                csp_vuln = CSPVulnerability(warn_msg, severity.HIGH)            
-                vulns_lst.append(csp_vuln)
-        if len(vulns_lst) > 0:
-            vulns[CSP_DIRECTIVE_XSS] = vulns_lst  
-    
-    #Check if misspelled directives name exists
-    if CSP_MISSPELLED_DIRECTIVES in policies_all:        
-        directive_values = policies_all[CSP_MISSPELLED_DIRECTIVES]                                                                                      
-        warn_msg = "Some directives are misspelled: " + ', '.join(directive_values)
-        csp_vuln = CSPVulnerability(warn_msg, severity.HIGH)            
-        vulns[CSP_MISSPELLED_DIRECTIVES] = [csp_vuln]
-                                 
-    return vulns
-    
+    @property
+    def source_limit(self):
+        return self._source_limit
 
+    @source_limit.setter
+    def source_limit(self, value):
+        self._source_limit = value
 
-def unsafe_inline_enabled(response):
-    """
-    Method to detect if CSP Policies are specified for Script/Style, 
-    to allow unsafe inline content to be loaded.
-    
-    :param response: A HTTPResponse object.
-    :return: True if CSP Policies are specified for Script/Style to allow 
-             unsafe inline content to be loaded, False otherwise. 
-    """
-    ##Extract and merge all policies
-    non_report_only_policies = retrieve_csp_policies(response)
-    report_only_policies = retrieve_csp_policies(response, True)
-    policies_all = merge_policies_dict(non_report_only_policies, report_only_policies)
-    #Parse policies dictionary : Iterate on Values
-    if(len(policies_all) > 0):
-        for directive_name in policies_all:
-            #Apply check only on Script and Style directives in order to be 
-            #coherent with the W3C Specs, because only theses 2 directives 
-            #supports the "unsafe-inline" directive value...
-            if (directive_name.lower() != CSP_DIRECTIVE_SCRIPT 
-                and directive_name.lower() != CSP_DIRECTIVE_STYLE):
-                continue
-            #Iterate on Directive values (normally values here are all URI)
-            for directive_value in policies_all[directive_name]:               
-                if directive_value.strip().lower() == CSP_DIRECTIVE_VALUE_UNSAFE_INLINE:
-                    #Return directly to enhance performance...
-                    return True
-    return False
+    def init_value(self, directive_value):
+        """
+        Init value of directive.
 
+        :param directive_value: string value of directive 
+        :return: True if initialization was success, otherwise False 
+        """
+        directive_value = directive_value.strip()
+        if not directive_value:
+            return False
+        self.value = directive_value
+        self.source_list = self._parse_source_list(directive_value)
+        if not self.source_list:
+            return False
+        return True
 
-def unsafe_eval_enabled(response):
-    """
-    Method to detect if CSP Policies are specified for Script, 
-    to allow use of the javascript "eval()" function.
-    
-    :param response: A HTTPResponse object.
-    :return: True if CSP Policies are specified for Script to allow 
-             use of the javascript "eval()" function, False otherwise. 
-    """
-    ##Extract and merge all policies
-    non_report_only_policies = retrieve_csp_policies(response)
-    report_only_policies = retrieve_csp_policies(response, True)
-    policies_all = merge_policies_dict(non_report_only_policies, report_only_policies)
-    #Parse policies dictionary : Iterate on Values
-    if(len(policies_all) > 0):
-        for directive_name in policies_all:
-            #Apply check only on Script directive in order to be 
-            #coherent with the W3C Specs, because only this directive 
-            #supports the "unsafe-eval" directive value...
-            if directive_name.lower() != CSP_DIRECTIVE_SCRIPT:
-                continue
-            #Iterate on Directive values (normally values here are all URI)
-            for directive_value in policies_all[directive_name]:               
-                if directive_value.strip().lower() == CSP_DIRECTIVE_VALUE_UNSAFE_EVAL:
-                    #Return directly to enhance performance...
-                    return True
-    return False
-    
+    def _normalize_host_source(self, token):
+        """
+        Normalize host source for furher processing.
 
-def provides_csp_features(response):
-    """
-    Method to detect if url provides CSP features.
-    
-    :param response: A HTTPResponse object.
-    :return: True if the URL provides CSP features, False otherwise. 
-    """
-    return ((len(retrieve_csp_policies(response)) 
-             + len(retrieve_csp_policies(response, True))) > 0)
+        :param token: string token of source  
+        :return: normalized host source value
+        """
+        result = token
+        o = urlparse(result)
+        # scheme-part
+        if not o.scheme:
+            result = '//' + result
+        # port-part
+        result = result.replace(":*", ":0")
+        # host-part
+        result = result.replace("*.", "Q.")
+        result = result.replace("*", "A")
+        return result
 
-def retrieve_csp_report_uri(response):
-    """
-    Method to retrieve all report uri from CSP Policies specified into a HTTP 
-    response through CSP headers.
-       
-    :param response: A HTTPResponse object.      
-    :return: A set of URIs
-    """ 
-    uri_set = set()
-    ##Extract and all merge policies
-    non_report_only_policies = retrieve_csp_policies(response)
-    report_only_policies = retrieve_csp_policies(response, True)
-    policies_all = merge_policies_dict(non_report_only_policies, report_only_policies)
-    #Iterate on Directives
-    if(len(policies_all) > 0):
-        for directive_name in policies_all:
-            if directive_name.lower() != CSP_DIRECTIVE_REPORT_URI:
-                continue
-            #Iterate on Directive values (normally values here are all URI)
-            for directive_value in policies_all[directive_name]:               
-                uri = directive_value.strip().lower()
-                uri_set.add(uri)                       
-    return uri_set
+    def _is_host_source(self, token):
+        """
+        Check if token is host-source.
 
-def retrieve_csp_policies(response, select_only_reportonly_policies=False,
-                          select_also_misspelled_directives=False):
-    """
-    Method to retrieve all CSP Policies specified into a HTTP response 
-    through CSP headers.
-       
-    :param response: A HTTPResponse object.
-    :param select_only_reportonly_policies: Optional parameter to indicate to 
-                                            method to retrieve only REPORT-ONLY 
-                                            CSP policies (default is False).
-    :param select_also_misspelled_directives: Optional parameter to indicate to 
-                                            method to retrieve also list of 
-                                            misspelled directives name
-                                            (default is False). List is saved 
-                                            in a dedicated KEY, see global var 
-                                            named "CSP_MISSPELLED_DIRECTIVES".       
-    :return: A dictionary in which KEY is a CSP directive and VALUE is the 
-             list of associated policies.
-    """   
-    headers = response.get_headers()
-    policies = {}
-    
-    #List of allowed CSP directive names
-    directive_allowed_names = [CSP_DIRECTIVE_DEFAULT, CSP_DIRECTIVE_SCRIPT,
-                               CSP_DIRECTIVE_OBJECT, CSP_DIRECTIVE_STYLE,
-                               CSP_DIRECTIVE_IMAGE, CSP_DIRECTIVE_MEDIA,
-                               CSP_DIRECTIVE_FRAME, CSP_DIRECTIVE_FONT,
-                               CSP_DIRECTIVE_CONNECTION,
-                               CSP_DIRECTIVE_REPORT_URI, CSP_DIRECTIVE_FORM,
-                               CSP_DIRECTIVE_SANDBOX,
-                               CSP_DIRECTIVE_SCRIPT_NONCE,
-                               CSP_DIRECTIVE_PLUGIN_TYPES, CSP_DIRECTIVE_XSS]
-
-    #Misspelled directives name list
-    misspelled_directives_name = []
-         
-    for header_name in headers:
-        header_name_upperstrip = header_name.upper().strip()
-        #Define header processing condition according to 
-        #"select_only_reportonly_policies" parameter value 
-        if not select_only_reportonly_policies:
-            if (header_name_upperstrip != CSP_HEADER_W3C.upper() 
-                and header_name_upperstrip != CSP_HEADER_FIREFOX.upper() 
-                and header_name_upperstrip != CSP_HEADER_CHROME.upper() 
-                and header_name_upperstrip != CSP_HEADER_IE.upper()):
-                continue
-        else:
-            if header_name_upperstrip != CSP_HEADER_W3C_REPORT_ONLY.upper():
-                continue                              
-        #Process header value	                   	
-        #Retrieve the CSP directive list : A Policy is defined by a directive 
-        #name and one or several associated values
-        directive_list = headers[header_name].strip()
-        #Parse CSP directives list using W3C Specs algorithm : 
-        #A CSP header value can specify several directives using ";" separator
-        directives = directive_list.split(";")
-        #For each directive we extract the directive name and is values 
-        #(several can be specified)
-        for directive in directives:
-            directive_strip = directive.strip()
-            #Manage empty case
-            if len(directive_strip) <= 0:
-                continue            
-            #Directive name and value are separated by a single space 
-            #Value can itself contains several sub values separated by a space
-            parts = directive_strip.split(" ")            
-            #Manage special directives cases
-            if (_contains_special_directive(directive_strip) 
-                and len(parts) == 1):
-                directive_name = parts[0].lower() 
-                policies[directive_name] = [""]
-                continue                        
-            #There must exists at least 2 parts otherwise we ignore the value...
-            if len(parts) < 2:
-                continue
-            #Retrieve directive name
-            directive_name = parts[0].lower()
-            #Check directive name is in allowed list of directives
-            if directive_name not in directive_allowed_names:
-                if (select_also_misspelled_directives and
-                    directive_name not in misspelled_directives_name):
-                    misspelled_directives_name.append(directive_name)
-                #Next directive...
-                continue
-            #Retrieve directive valueS
-            parts.pop(0)
-            directive_values = parts
-            #Add policy to dictionary
-            if directive_name not in policies:
-                policies[directive_name] = []
-            for directive_value in directive_values:
-                #Remove quote and double quote from value to unify result 
-                #string content
-                tmp_value = directive_value.replace("'", "")
-                tmp_value = tmp_value.replace('"', '')
-                #Avoid empty value
-                if len(tmp_value.strip()) > 0:             			
-                    policies[directive_name].append(tmp_value)
-    
-    #Do cleanup: Remove directive name without any policies
-    policies = dict((k, v) for k, v in policies.iteritems() if len(v) > 0)
-    
-    #Add misspelled directives names list if dedicated flag is set
-    if (select_also_misspelled_directives 
-        and len(misspelled_directives_name) > 0):
-        policies[CSP_MISSPELLED_DIRECTIVES] = misspelled_directives_name
-                    
-    return policies
-
-def merge_policies_dict(non_report_only_policies_dict, report_only_policies_dict):
-    """
-    Method to merge 2 Policies dictionaries to a single.
-               
-    :param non_report_only_policies_dict: A dictionary with all non 
-                                          REPORT-ONLY Policies 
-                                          (return of method "retrieve_csp_policies").
-    :param report_only_policies_dict: A dictionary with all REPORT-ONLY 
-                                      Policies 
-                                      (return of method "retrieve_csp_policies")
-    :return: A merged dictionary in which KEY is a CSP directive 
-             and VALUE is the list of associated policies.
-    """
-    #Short circuit precheck...
-    if(non_report_only_policies_dict is None 
-       or len(non_report_only_policies_dict) == 0):
-        return report_only_policies_dict
-    if(report_only_policies_dict is None 
-       or len(report_only_policies_dict) == 0):
-        return non_report_only_policies_dict
-    
-    merged_policies = {}
-    #Create a list from union of directives names (remove duplicate items)
-    directives_names = list(set(non_report_only_policies_dict.keys() 
-                                + report_only_policies_dict.keys()))
-    #Parse it to merge list of values for each key (remove duplicate items)
-    for k in directives_names:
-        values = []
-        if k in non_report_only_policies_dict:
-            values.extend(non_report_only_policies_dict[k])
-        if k in report_only_policies_dict:
-            values.extend(report_only_policies_dict[k])
-        merged_policies[k] = list(set(values))        
-    return merged_policies
-
-
-def _contains_special_directive(directive_definition):
-    """
-    Internal method to detect in a directive specification if
-    a "special" directive is used.
-    
-    :param directive_definition: Content of the directive (name + values).
-    
-    :return: TRUE only if a special directive is detected. 
-    """
-    #Manage empty cases
-    if directive_definition is None:
-        return False
-
-    if len(directive_definition.strip()) == 0:
-        return False
-    
-    #List of directives for which empty value is a behavior specification
-    special_directive_names = [CSP_DIRECTIVE_SANDBOX,
-                               CSP_DIRECTIVE_SCRIPT_NONCE]
-
-    tmp = directive_definition.lower()
-    for special_directive in special_directive_names:
-        if special_directive in tmp:
+        :param token: string token of source
+        :return: boolean result
+        """
+        if token.startswith("'"):
+            return False
+        tmp = self._normalize_host_source(token)
+        o = urlparse(tmp)
+        if re.search("[^a-zA-Z:*0-9.-]", o.netloc):
+            return False
+        if o.geturl() == tmp:
             return True
+
+    def _is_valid_source(self, token):
+        """
+        Check if token is valid source.
+        See also https://www.w3.org/TR/CSP/#source-list-syntax
+
+        :param token: string token of source
+        :return: boolean result
+        """
+        if token == "*":
+            return True
+        # keyword-source
+        if token in ["'self'", "'unsafe-inline'", "'unsafe-eval'"]:
+            return True
+        # nonce-source
+        p = re.compile("'nonce-[a-zA-Z0-9=]+'")
+        if p.match(token):
+            return True
+        # hash-source
+        p = re.compile("'(sha256|sha384|sha512)-[a-zA-Z0-9=]+'")
+        if p.match(token):
+            return True
+        # scheme-source 
+        tmp = self._normalize_host_source(token)
+        o = urlparse(tmp)
+        if o.scheme + ':' == tmp:
+            return True
+        # host-source
+        if self._is_host_source(token):
+            return True
+        return False
+
+    def _parse_source_list(self, directive_value):
+        """
+        Parse directive value.
+        See also https://www.w3.org/TR/CSP/#source-list-parsing
+
+        :param directive_value: string directive value
+        :return: list of sources
+        """
+        source_list = directive_value.strip()
+        if source_list.lower() == "'none'":
+            return []
+        result = []
+        for token in source_list.split(" "):
+            if self._is_valid_source(token):
+                result.append(token)
+        return result
+
+    def _inline_signed(self):
+        """
+        Check if there are nonces or hashes in source list.
+
+        :return: True if there are nonces or hashes in source list
+        """
+        result = False
+        for source_expression in self.source_list:
+            for s in ["'nonce-", "'sha256-", "'sha384-", "'sha512-"]:
+                if source_expression.startswith(s):
+                    result = True
+        return result
+
+    def _find_wildcard_vulns(self, severity):
+        """
+        Find wildcard vulnerabilities.
+
+        :param severity: Severity for results 
+        :return: list of vulnerabilities
+        """
+        vulns_lst = []
+        if "*" in self.source_list:
+            vuln = CSPVulnerability(self.vuln_wildcard_tpl % self.name,
+                    severity, 'wildcard', self.name)
+            vulns_lst = [vuln]
+        return vulns_lst
+
+    def _check_source_limit(self):
+        """
+        Find source limit exceed vulnerabilities 
+        (when too many sources in directive source list).
+
+        :return: list of vulnerabilities
+        """
+        vulns_lst = []
+        if not self.source_limit:
+            return vulns_lst
+        if  len(self.source_list) > self.source_limit:
+            vuln = CSPVulnerability(self.vuln_source_limit_tpl % self.name, 
+                    severity.LOW, 'source_limit', self.name)
+            vulns_lst = [vuln]
+        return vulns_lst
+
+    def _check_untrusted_sources(self):
+        """
+        Find untrusted hosts in source list.
+
+        :return: list of vulnerabilities
+        """
+        untrusted = []
+        vulns_lst = []
+        for source in self.source_list:
+            if self._is_host_source(source):
+                tmp = self._normalize_host_source(source)
+                o = urlparse(tmp)
+                for t_host in self.trusted_hosts:
+                    if not o.hostname.endswith(t_host):
+                        untrusted.append(source)
+        if untrusted:
+            vuln = CSPVulnerability(self.vuln_untrust_tpl % (self.name, ",".join(untrusted)), 
+                    severity.LOW, 'untrust', self.name)
+            vulns_lst = [vuln]
+        return vulns_lst
+
+    def find_vulns(self):
+        """
+        Find all vulnerabilities in directive.
+
+        :return: list of vulnerabilities
+        """
+        # TODO 
+        # 1. Check for random value in nonce
+        # 3. Check for data: & blob: in script-src & default-src 
+        # https://www.w3.org/TR/CSP/#source-list-guid-matching
+        #
+        vulns = []
+        vulns.extend(self._find_wildcard_vulns(severity.MEDIUM))
+        vulns.extend(self._check_source_limit())
+        vulns.extend(self._check_untrusted_sources())
+
+        if self.unsafe_inline_enabled() and not self._inline_signed():
+            vuln = CSPVulnerability(self.vuln_inline_tpl % self.name, severity.HIGH, 'inline', self.name)
+            vulns.append(vuln)
+        if "'unsafe-eval'" in self.source_list:
+            vuln = CSPVulnerability(self.vuln_eval_tpl % self.name, severity.MEDIUM, 'eval', self.name)
+            vulns.append(vuln)
+        return vulns
+     
+    def __str__(self):
+        return self.name + " " + self.value
+ 
+    def __eq__(self, other):
+        return self.name.upper() == other.name.upper()
+
+    def unsafe_inline_enabled(self):
+        """
+        Check if there is 'unsafe-inline' keyword in source list.
+
+        :return: True if there is 'unsafe-inline' in source list
+        """
+        return "'unsafe-inline'" in self.source_list
+
+class DefaultSrcDirective(CSPDirective):
+    """
+    Represents CSP 'default-src' directive.
+    """
+    name = "default-src"
+
+    @CSPDirective.source_limit.setter
+    def source_limit(self, value):
+        """
+        Set smaller value because of risky nature of the directive.
+
+        :param value: new value for directive
+        """
+        value = value if not value else int(value/2)
+        self._source_limit = value
+
+class ScriptSrcDirective(CSPDirective):
+    """
+    Represents CSP 'script-src' directive.
+    """
+    name = "script-src"
+
+    @CSPDirective.source_limit.setter
+    def source_limit(self, value):
+        """
+        Set smaller value because of risky nature of the directive.
+
+        :param value: new value for directive
+        """
+        value = value if not value else int(value/2)
+        self._source_limit = value
+
+class FrameAncestorsDirective(CSPDirective):
+    """
+    Represents CSP 'frame-ancestors' directive.
+    """
+    name = "frame-ancestors"
     
-    return False
+    def find_vulns(self):
+        """
+        Find all vulnerabilities in the directive.
+
+        :return: list of vulnerabilities
+        """
+        vulns = []
+        if not self.source_list:
+            vuln = CSPVulnerability(self.vuln_required_tpl % self.name, severity.MEDIUM)
+            vulns.append(vuln)
+        vulns.extend(super(FrameAncestorsDirective, self).find_vulns())
+        return vulns
+
+class FormActionDirective(CSPDirective):
+    """
+    Represents CSP 'form-action' directive.
+    """
+    name = "form-action"
+
+    def find_vulns(self):
+        """
+        Find all vulnerabilities in the directive.
+
+        :return: list of vulnerabilities
+        """
+        vulns = []
+        if not self.source_list:
+            vuln = CSPVulnerability(self.vuln_required_tpl % self.name, severity.MEDIUM,
+                    'required', self.name)
+            vulns.append(vuln)
+        vulns.extend(super(FormActionDirective, self).find_vulns())
+        return vulns
+ 
+class SandboxDirective(CSPDirective):
+    """
+    Represents CSP 'sandbox' directive.
+    """
+    name = "sandbox"
+    flags = []
+
+    def init_value(self, directive_value):
+        """
+        Init value of directive.
+
+        :param directive_value: string value of directive 
+        :return: True if initialization was success, otherwise False 
+        """
+        self.value = directive_value
+        self.flags = self._parse_flag_list(directive_value)
+        return True
+
+    def _valid_flag(self, flag):
+        """
+        Check if flag is valid
+
+        :return: True if flag is valid
+        """
+        valid_flags = ['allow-forms', 'allow-pointer-lock', 
+                'allow-popups', 'allow-same-origin',
+                'allow-scripts', 'allow-top-navigation',]
+
+        if flag in valid_flags:
+            return True
+        else:
+            return False
+
+    def _parse_flag_list(self, directive_value):
+        """
+        Parse flag list for sandbox directive.
+
+        :param directive_value: value of directive
+        :return: list of flags
+        """
+        flag_list = directive_value.strip()
+        result = []
+        for flag in flag_list.split(" "):
+            if self._valid_flag(flag):
+                result.append(flag)
+        return result
+
+class PluginTypesDirective(CSPDirective):
+    """
+    Represents CSP 'plugin-types' directive.
+    """
+    # https://www.w3.org/TR/CSP/#media-type-list-syntax 
+    name = "plugin-types"
+    media_type_list = []
+
+    def init_value(self, directive_value):
+        """
+        Init value of directive.
+
+        :param directive_value: string value of directive 
+        :return: True if initialization was success, otherwise False 
+        """
+        directive_value = directive_value.strip()
+        if not directive_value:
+            return False
+        self.value = directive_value
+        self.media_type_list = self._parse_media_type_list(directive_value)
+        return True
+
+    def _valid_media_type(self, media_type):
+        """
+        Check if media type is valid.
+
+        :param media_type: media type
+        :return: True if is valid
+        """
+        if media_type.lower() not in MIME_TYPES:
+            return False
+        return True
+
+    def _parse_media_type_list(self, directive_value):
+        """
+        Parse media type list.
+        See also https://www.w3.org/TR/CSP/#media-type-list-parsing
+        
+        :param directive_value: directive value
+        :return: list of media types
+        """
+        media_type_list = directive_value.strip()
+        result = []
+        for media_type in media_type_list.split(" "):
+            if self._valid_media_type(media_type):
+                result.append(media_type)
+        return result
+
+class CSPPolicy(object):
+    """
+    Represents policy from Content Security Policy Level 2
+    https://www.w3.org/TR/CSP/
+    """
+    version = 2
+    report_only = False
+    directives = []
+    syntax_errors = []
+    value = ""
+    trusted_hosts = []
+    source_limit = None
+    vuln_syntax_tpl = "Can't parse the CSP policy %s."
+
+    def get_header_name(self, report_only=False):
+        """
+        :param report_only: flag for result
+        :return: CSP header name
+        """
+        header_name = "Content-Security-Policy"
+        if self.report_only or report_only:
+            header_name += "-Report-Only"
+        return header_name
+
+    def pretty(self):
+        """
+        :return: pretty string representation of CSP policy
+        """
+        return self.get_header_name() + ":\n" + ";\n".join([str(d) for d in self.directives])
+
+    def __str__(self):
+        return self.get_header_name() + ": " + self.value
+
+    def init_value(self, csp_value, banned_directives=[]):
+        """
+        Init value of the policy.
+
+        :param csp_value: string value of policy
+        :param banned_directives: list of banned directives (see meta tag)
+        :return: True if initialization was success, otherwise False 
+        """
+        self.syntax_errors = []
+        string_policy = csp_value.strip()
+        if not string_policy:
+            return False
+        self.directives = self._parse_policy(string_policy, banned_directives)
+        if len(self.directives):
+            self.value = csp_value
+            return True
+        else:
+            self.syntax_errors.append(
+                    CSPVulnerability(self.vuln_syntax_tpl % csp_value, 
+                        severity.HIGH, 'syntax', ''))
+            return False
+
+    def init_from_header(self, header_name, header_value):
+        """
+        Init policy from CSP header.
+
+        :param header_name: CSP header name
+        :param header_value: CSP header value
+        :return: True if initialization was success
+        """
+        string_policy = ""
+
+        if header_name.upper().strip() == self.get_header_name().upper():
+            string_policy = header_value.strip()
+        elif header_name.upper().strip() == self.get_header_name(True).upper():
+            self.report_only = True
+            string_policy = header_value.strip()
+        return self.init_value(string_policy)
+
+    def make_directive(self, directive_name):
+        """
+        Make directive instance (factory method).
+
+        :param directive_name: directive name for new directive
+        :return: directive instance
+        """
+        simple_directives = [
+            "object-src", "img-src", "media-src",
+            "frame-src", "font-src", "connect-src", 
+            "report-uri", "base-uri", "child-src", 
+            "style-src"
+            ]
+        directive = None
+        dname = directive_name.lower()
+        if dname in simple_directives:
+            directive = CSPDirective(dname)
+        elif "default-src" == dname:
+            directive = DefaultSrcDirective()
+        elif "script-src" == dname:
+            directive = ScriptSrcDirective()
+        elif "frame-ancestors" == dname:
+            directive = FrameAncestorsDirective()
+        elif "form-action" == dname:
+            directive = FormActionDirective()
+        elif "sandbox" == dname:
+            directive = SandboxDirective()
+        elif "plugin-types" == dname:
+            directive = PluginTypesDirective()
+        
+        if directive:
+            directive.source_limit = self.source_limit
+            directive.trusted_hosts = self.trusted_hosts
+            return directive
+        else:
+            return None
+
+    def _parse_policy(self, string_policy, banned_directives=[]):
+        """
+        Parse CSP policy.
+        See also https://www.w3.org/TR/CSP/#policy-parsing
+
+        :param string_policy: string value of policy
+        :param banned_directives: list of banned directives (see meta tag)
+        :return: result list of directives
+        """
+        result = []
+        tokens = [d.strip() for d in string_policy.strip().split(";")]
+        tokens = filter(lambda x:x.strip(), tokens)
+
+        for t in tokens:
+            directive_name = t
+            directive_value = ""
+            i = t.find(" ")
+
+            if i != -1:
+                directive_name = t[:i]
+                directive_value = t[i+1:]
+
+            if directive_name in banned_directives:
+                continue
+            
+            directive = self.make_directive(directive_name)
+            # CSP syntax error
+            if not directive:
+                return []
+            if directive not in result:
+                if directive.init_value(directive_value):
+                    result.append(directive)
+        return result
+
+    def get_directive_by_name(self, directive_name):
+        """
+        Get directive by name.
+
+        :param directive_name: name of directive
+        :return: directive if it exists in the policy, otherwise None 
+        """
+        for d in self.directives:
+            if d.name.lower() == directive_name.lower():
+                return d
+        return None
+
+    def find_vulns(self):
+        """
+        Find all vulnerabilities in all directives.
+
+        :return: result list of vulnerabilities
+        """
+        vulns = []
+        for d in self.directives:
+            d_vulns  = d.find_vulns()
+            if d_vulns:
+                vulns.extend(d_vulns)
+        return vulns + self.syntax_errors
+    
+    def find_vulns_by_directive(self, directive_name):
+        """
+        Find all vulnerabilities filtered by directive.
+
+        :param directive_name: directive name
+        :return: list of vulnerabilities
+        """
+        result = []
+        for v in self.find_vulns():
+            if v.directive == directive_name:
+                result.append(v)
+        return result
+
+    def get_report_uri(self):
+        """
+        Get report uri if it exists.
+
+        :return: report uri, otherwise None
+        """
+        report_uri = self.get_directive_by_name('report-uri')
+        
+        if report_uri:
+            return report_uri.value
+        else:
+            return None
+
+    def protects_against_xss(self):
+        """
+        Check if policy protects against XSS.
+        See also https://www.w3.org/TR/CSP/#directives
+        
+        :return: True if protects, otherwise False
+        """
+        if not self.directives or self.report_only:
+            return False
+
+        risky_directives = []
+        for dn in ['script-src', 'object-src', 'script-src']:
+            risky_directives.append(self.get_directive_by_name(dn))
+        default_src = self.get_directive_by_name('default-src')
+
+        # must be enabled default_src or **all** risky directives
+        if not (default_src or \
+                reduce(lambda x, y: x and y, risky_directives)):
+            return False
+
+        for rd in risky_directives:
+            d = rd if rd else default_src
+            for vuln in d.find_vulns():
+                if vuln.severity == severity.HIGH:
+                    return False
+        return True
+
+    def unsafe_inline_enabled(self):
+        """
+        Check if there is 'unsafe-inline' keyword in source list of 
+        script-src and style-src directives.
+
+        :return: True if there is 'unsafe-inline' in source list of risky directives
+        """
+        for directive_name in ['script-src', 'style-src']:
+            directive = self.get_directive_by_name(directive_name)
+            if directive and directive.unsafe_inline_enabled():
+                return True
+        return False
+
+class CSP(object):
+    """Content Security Policy Level 2
+    https://www.w3.org/TR/CSP/"""
+    policies = []
+    response_id = None
+    response_url = None
+    trusted_hosts = []
+    source_limit = None
+
+    def header_provides_csp(self, header_name):
+        """
+        Indicate if header is CSP header.
+
+        :param header_name: name of the header
+        :return: True if so, otherwise False
+        """
+        csp = CSPPolicy()
+        header = header_name.upper().strip()
+        if header == csp.get_header_name().upper() \
+                or header == csp.get_header_name(True).upper():
+            return True
+        return False
+
+    def _get_policies_from_meta(self, response):
+        """
+        Retrieve policy from meta tag.
+        See also https://www.w3.org/TR/CSP/#delivery-html-meta-element
+        
+        :param response: HTTP response
+        :return: list of policies
+        """
+        result = []
+
+        if not response.is_text_or_html():
+            return result
+
+        try:
+            dp = parser_cache.dpc.get_document_parser_for(response)
+        except BaseFrameworkException:
+            return result
+
+        meta_tag_list = dp.get_meta_tags()
+        meta_values = []
+        for tag in meta_tag_list:
+            if tag.get('http-equiv', '') == "Content-Security-Policy":
+                content = tag.get('content', '')
+                if content:
+                    meta_values.append(content)
+        banned = ['report-uri', 'frame-ancestors', 'sandbox']
+        for csp_value in meta_values:
+            csp = CSPPolicy()
+            csp.source_limit = self.source_limit
+            csp.trusted_hosts = self.trusted_hosts
+            if csp.init_value(csp_value, banned_directives=banned):
+                result.append(csp)
+         
+        return result
+
+    def init_from_response(self, response):
+        """
+        Init CSP policies from HTTP response.
+
+        :param response: HTTP response
+        :return: list of policies
+        """
+        # TODO
+        # Merge multiple policies 
+        # https://www.w3.org/TR/CSP/#enforcing-multiple-policies 
+        self.policies = []
+        # From headers
+        headers = response.get_headers()
+        for header_name in headers:
+            if self.header_provides_csp(header_name):
+                csp = CSPPolicy()
+                csp.source_limit = self.source_limit
+                csp.trusted_hosts = self.trusted_hosts
+                if csp.init_from_header(header_name, headers[header_name]):
+                    self.policies.append(csp)
+        # From meta tag
+        self.policies.extend(self._get_policies_from_meta(response))
+        if self.policies:
+            self.response_id = response.id
+            self.response_url = response.get_url().uri2url()
+            return len(self.policies)
+        else:
+            return False
+
+    def protects_against_xss(self):
+        """
+        Check if policies protect against XSS.
+        See also https://www.w3.org/TR/CSP/#directives
+        
+        :return: True if at least one of policies protects, otherwise False
+        """
+        for policy in self.policies:
+            if policy.protects_against_xss():
+                return True
+        return False
+
+    def __str__(self):
+        return '|'.join([p.value for p in self.policies]) 
+
+    def __hash__(self):
+        return hash(str(self))
+
+    def __eq__(self, other):
+        return hash(self) == hash(other)

--- a/w3af/core/controllers/csp/utils.py
+++ b/w3af/core/controllers/csp/utils.py
@@ -372,7 +372,7 @@ class DefaultSrcDirective(CSPDirective):
 
         for strictness, value in strictness_levels:
             if self.strictness == strictness \
-                    and (len(self.source_list) > 1 or self.source_list[0] != value):
+                    and (len(self.source_list) > 1 or (self.source_list and self.source_list[0] != value)):
                 vuln = CSPVulnerability(self.vuln_strictness_tpl % value, severity.MEDIUM,
                     'default_src_strictness', self.name)
                 vulns.append(vuln)

--- a/w3af/core/controllers/csp/utils.py
+++ b/w3af/core/controllers/csp/utils.py
@@ -8,7 +8,7 @@ This file is part of w3af, http://w3af.org/ .
 w3af is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation version 2 of the License.
-    
+   
 w3af is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -26,14 +26,16 @@ import w3af.core.data.constants.severity as severity
 from w3af.core.controllers.exceptions import BaseFrameworkException
 import w3af.core.data.parsers.parser_cache as parser_cache
 
-#Valid Mime Types list
+# Valid Mime Types list
 MIME_TYPES = MimeTypes().types_map[1].values()
 
-#Define NamedTuple tuple subclass to represents a CSP vulnerability.
-#Declare type here in order to expose it with project visibility
-#and permit cPickle processing to see it. See link below:
-#http://stackoverflow.com/questions/4677012/python-cant-pickle-type-x-attribute-lookup-failed
-CSPVulnerability = namedtuple('CSPVulnerability', ['desc', 'severity', 'type', 'directive'])            
+# Define NamedTuple tuple subclass to represents a CSP vulnerability.
+# Declare type here in order to expose it with project visibility
+# and permit cPickle processing to see it. See link below:
+# http://stackoverflow.com/questions/4677012/python-cant-pickle-type-x-attribute-lookup-failed
+CSPVulnerability = namedtuple('CSPVulnerability',
+                              ['desc', 'severity', 'type', 'directive'])
+
 
 class CSPDirective(object):
     """
@@ -44,6 +46,7 @@ class CSPDirective(object):
     source_list = []
     _source_limit = None
     trusted_hosts = []
+    syntax_errors = []
 
     vuln_wildcard_tpl = "Directive '%s' allows all sources."
     vuln_inline_tpl = "Directive '%s' allows 'unsafe-inline'. Use nonces or hashes."
@@ -53,13 +56,13 @@ or equivalent like blob: or filesystem:. Found: %s."""
     vuln_source_limit_tpl = "Directive '%s' contains too many sources in source list."
     vuln_data_source_tpl = """Directive '%s' contains 'data:' in source list. 
 Allowing 'data:' URLs is equivalent to 'unsafe-inline'."""
-    vuln_required_tpl = """Directive '%s' is not defined. NB! It does not fall back 
-to the default sources when the directive is not defined."""
+    vuln_parse_source_tpl = """CSP policy parsing error. 
+The source list for directive '%s' contains an invalid source: %s."""
 
     def __init__(self, name=None):
         if name:
             self.name = name
-    
+   
     @property
     def source_limit(self):
         return self._source_limit
@@ -72,23 +75,20 @@ to the default sources when the directive is not defined."""
         """
         Init value of directive.
 
-        :param directive_value: string value of directive 
-        :return: True if initialization was success, otherwise False 
+        :param directive_value: string value of directive
+        :return: True if initialization was success, otherwise False
         """
         directive_value = directive_value.strip()
-        if not directive_value:
+        if not self._parse_source_list(directive_value):
             return False
         self.value = directive_value
-        self.source_list = self._parse_source_list(directive_value)
-        if not self.source_list:
-            return False
         return True
 
     def _normalize_host_source(self, token):
         """
         Normalize host source for furher processing.
 
-        :param token: string token of source  
+        :param token: string token of source
         :return: normalized host source value
         """
         result = token
@@ -142,7 +142,7 @@ to the default sources when the directive is not defined."""
         p = re.compile("'(sha256|sha384|sha512)-[a-zA-Z0-9+/]+[=]{0,2}'")
         if p.match(token):
             return True
-        # scheme-source 
+        # scheme-source
         tmp = self._normalize_host_source(token)
         o = urlparse(tmp)
         if o.scheme + ':' == tmp:
@@ -154,20 +154,27 @@ to the default sources when the directive is not defined."""
 
     def _parse_source_list(self, directive_value):
         """
-        Parse directive value.
+        Parse directive value and set up directive sourse list.
         See also https://www.w3.org/TR/CSP/#source-list-parsing
 
         :param directive_value: string directive value
-        :return: list of sources
+        :return: True if source list was successfully parsed
         """
+        self.syntax_errors = []
         source_list = directive_value.strip()
         if source_list.lower() == "'none'":
-            return []
+            self.source_list = []
+            return True
         result = []
         for token in source_list.split(" "):
             if self._is_valid_source(token):
                 result.append(token)
-        return result
+            else:
+                self.syntax_errors.append(
+                    CSPVulnerability(self.vuln_parse_source_tpl % (self.name, token),
+                    severity.HIGH, 'syntax', ''))
+        self.source_list = result
+        return True
 
     def get_nonces_hashes(self, nonces=True, hashes=True):
         """
@@ -194,33 +201,33 @@ to the default sources when the directive is not defined."""
         """
         Find wildcard vulnerabilities.
 
-        :param severity: Severity for results 
+        :param severity: Severity for results
         :return: list of vulnerabilities
         """
         vulns = []
         if "*" in self.source_list:
             vuln = CSPVulnerability(self.vuln_wildcard_tpl % self.name,
-                    severity, 'wildcard', self.name)
+                                    severity, 'wildcard', self.name)
             vulns = [vuln]
         return vulns
 
     def _check_data_source(self):
         """
-        Check if data: is included in source list of risky directives 
+        Check if data: is included in source list of risky directives
 
         :return: list of vulnerabilities
         """
         vulns = []
         if 'data:' in self.source_list \
                 and self.name in ['default-src', 'script-src', 'object-src']:
-            vuln = CSPVulnerability(self.vuln_data_source_tpl % self.name, 
-                    severity.HIGH, 'data_source', self.name)
+            vuln = CSPVulnerability(self.vuln_data_source_tpl % self.name,
+                severity.HIGH, 'data_source', self.name)
             vulns = [vuln]
         return vulns
 
     def _find_eval_vulns(self):
         """
-        Check if 'unsafe-eval' or equivalent is included in source list of directive. 
+        Check if 'unsafe-eval' or equivalent is included in source list of directive.
 
         :return: list of vulnerabilities
         """
@@ -231,21 +238,21 @@ to the default sources when the directive is not defined."""
         result = filter(lambda x: x == "'unsafe-eval'", self.source_list)
         # See "Security Considerations for GUID URL schemes"
         # https://www.w3.org/TR/CSP/#source-list-guid-matching
-        risky_schemes = filter(lambda x: x in ['blob:', 'filesystem:'], 
-                self.source_list)
+        risky_schemes = filter(lambda x: x in ['blob:', 'filesystem:'],
+            self.source_list)
 
         if self.name in ['default-src', 'script-src'] and risky_schemes:
             result.extend(risky_schemes)
-        
+       
         if result:
             vulns.append(CSPVulnerability(
-                self.vuln_eval_tpl % (self.name, ', '.join(result)), 
+                self.vuln_eval_tpl % (self.name, ', '.join(result)),
                 severity.MEDIUM, 'eval', self.name))
         return vulns
 
     def _check_source_limit(self):
         """
-        Find source limit exceed vulnerabilities 
+        Find source limit exceed vulnerabilities
         (when too many sources in directive source list).
 
         :return: list of vulnerabilities
@@ -253,9 +260,9 @@ to the default sources when the directive is not defined."""
         vulns = []
         if not self.source_limit:
             return []
-        if  len(self.source_list) > self.source_limit:
-            vuln = CSPVulnerability(self.vuln_source_limit_tpl % self.name, 
-                    severity.LOW, 'source_limit', self.name)
+        if len(self.source_list) > self.source_limit:
+            vuln = CSPVulnerability(self.vuln_source_limit_tpl % self.name,
+                severity.LOW, 'source_limit', self.name)
             vulns = [vuln]
         return vulns
 
@@ -279,10 +286,10 @@ to the default sources when the directive is not defined."""
                         break
                 else:
                     untrusted.append(source)
-        
+      
         if untrusted:
-            vuln = CSPVulnerability(self.vuln_untrust_tpl % (self.name, ", ".join(untrusted)), 
-                    severity.LOW, 'untrust', self.name)
+            vuln = CSPVulnerability(self.vuln_untrust_tpl % (self.name, ", ".join(untrusted)),
+                severity.LOW, 'untrust', self.name)
             vulns = [vuln]
         return vulns
 
@@ -293,14 +300,14 @@ to the default sources when the directive is not defined."""
         :return: list of vulnerabilities
         """
         return []
- 
+
     def find_vulns(self):
         """
         Find all vulnerabilities in directive.
 
         :return: list of vulnerabilities
         """
-        # TODO 
+        # TODO
         # 1. Check for random value in nonce
         # https://www.w3.org/TR/CSP/#source-list-guid-matching
         #
@@ -313,13 +320,14 @@ to the default sources when the directive is not defined."""
         vulns.extend(self._find_vulns())
 
         if self.unsafe_inline_enabled() and not self.get_nonces_hashes():
-            vuln = CSPVulnerability(self.vuln_inline_tpl % self.name, severity.HIGH, 'inline', self.name)
+            vuln = CSPVulnerability(self.vuln_inline_tpl % self.name, 
+                severity.HIGH, 'inline', self.name)
             vulns.append(vuln)
-        return vulns
-     
+        return vulns + self.syntax_errors
+
     def __str__(self):
         return self.name + " " + self.value
- 
+
     def __eq__(self, other):
         return self.name.upper() == other.name.upper()
 
@@ -330,6 +338,7 @@ to the default sources when the directive is not defined."""
         :return: True if there is 'unsafe-inline' in source list
         """
         return "'unsafe-inline'" in self.source_list
+
 
 class DefaultSrcDirective(CSPDirective):
     """
@@ -364,11 +373,12 @@ class DefaultSrcDirective(CSPDirective):
         for strictness, value in strictness_levels:
             if self.strictness == strictness \
                     and (len(self.source_list) > 1 or self.source_list[0] != value):
-                vuln = CSPVulnerability(self.vuln_strictness_tpl % value, severity.MEDIUM, 
-                        'default_src_strictness', self.name)
+                vuln = CSPVulnerability(self.vuln_strictness_tpl % value, severity.MEDIUM,
+                    'default_src_strictness', self.name)
                 vulns.append(vuln)
 
         return vulns
+
 
 class ScriptSrcDirective(CSPDirective):
     """
@@ -386,43 +396,7 @@ class ScriptSrcDirective(CSPDirective):
         value = value if not value else int(value/2)
         self._source_limit = value
 
-class FrameAncestorsDirective(CSPDirective):
-    """
-    Represents CSP 'frame-ancestors' directive.
-    """
-    name = "frame-ancestors"
-    
-    def _find_vulns(self):
-        """
-        Find all vulnerabilities in the directive.
 
-        :return: list of vulnerabilities
-        """
-        vulns = []
-        if not self.source_list:
-            vuln = CSPVulnerability(self.vuln_required_tpl % self.name, severity.MEDIUM)
-            vulns.append(vuln)
-        return vulns
-
-class FormActionDirective(CSPDirective):
-    """
-    Represents CSP 'form-action' directive.
-    """
-    name = "form-action"
-
-    def _find_vulns(self):
-        """
-        Find all vulnerabilities in the directive.
-
-        :return: list of vulnerabilities
-        """
-        vulns = []
-        if not self.source_list:
-            vuln = CSPVulnerability(self.vuln_required_tpl % self.name, severity.MEDIUM,
-                    'required', self.name)
-            vulns.append(vuln)
-        return vulns
- 
 class SandboxDirective(CSPDirective):
     """
     Represents CSP 'sandbox' directive.
@@ -434,8 +408,8 @@ class SandboxDirective(CSPDirective):
         """
         Init value of directive.
 
-        :param directive_value: string value of directive 
-        :return: True if initialization was success, otherwise False 
+        :param directive_value: string value of directive
+        :return: True if initialization was success, otherwise False
         """
         self.value = directive_value
         self.flags = self._parse_flag_list(directive_value)
@@ -447,9 +421,9 @@ class SandboxDirective(CSPDirective):
 
         :return: True if flag is valid
         """
-        valid_flags = ['allow-forms', 'allow-pointer-lock', 
-                'allow-popups', 'allow-same-origin',
-                'allow-scripts', 'allow-top-navigation',]
+        valid_flags = ['allow-forms', 'allow-pointer-lock',
+            'allow-popups', 'allow-same-origin',
+            'allow-scripts', 'allow-top-navigation']
 
         if flag in valid_flags:
             return True
@@ -470,11 +444,12 @@ class SandboxDirective(CSPDirective):
                 result.append(flag)
         return result
 
+
 class PluginTypesDirective(CSPDirective):
     """
     Represents CSP 'plugin-types' directive.
     """
-    # https://www.w3.org/TR/CSP/#media-type-list-syntax 
+    # https://www.w3.org/TR/CSP/#media-type-list-syntax
     name = "plugin-types"
     media_type_list = []
 
@@ -482,8 +457,8 @@ class PluginTypesDirective(CSPDirective):
         """
         Init value of directive.
 
-        :param directive_value: string value of directive 
-        :return: True if initialization was success, otherwise False 
+        :param directive_value: string value of directive
+        :return: True if initialization was success, otherwise False
         """
         directive_value = directive_value.strip()
         if not directive_value:
@@ -507,7 +482,7 @@ class PluginTypesDirective(CSPDirective):
         """
         Parse media type list.
         See also https://www.w3.org/TR/CSP/#media-type-list-parsing
-        
+       
         :param directive_value: directive value
         :return: list of media types
         """
@@ -517,6 +492,7 @@ class PluginTypesDirective(CSPDirective):
             if self._valid_media_type(media_type):
                 result.append(media_type)
         return result
+
 
 class CSPPolicy(object):
     """
@@ -532,9 +508,14 @@ class CSPPolicy(object):
     report_no_report_uri = False
     report_eval = True
     source_limit = None
-    vuln_syntax_tpl = "Can't parse the CSP policy %s."
-    vuln_no_report_uri_tpl = "The CSP policy doesn't contain 'report-uri' directive."
     default_src_strictness = 0
+    report_not_fallback = False
+    vuln_parse_directive_tpl = "CSP policy parsing error. Unrecognized directive '%s'."
+    vuln_no_report_uri_tpl = "The CSP policy doesn't contain 'report-uri' directive."
+    vuln_required_tpl = """Directive '%s' is not defined. NB! It does not fall back 
+to the default sources when the directive is not defined."""
+    vuln_default_tpl = """Directive 'default-src' is not defined. If a 'default-src' directive 
+is not explicitly specified, wildcard ('*') becomes default sources."""
 
     def get_header_name(self, report_only=False):
         """
@@ -550,8 +531,8 @@ class CSPPolicy(object):
         """
         :return: pretty string representation of CSP policy
         """
-        return self.get_header_name() + ":\n    " \
-                + ";\n    ".join([str(d) for d in self.directives])
+        return (self.get_header_name() + ":\n    "
+                + ";\n    ".join([str(d) for d in self.directives]))
 
     def __str__(self):
         return self.get_header_name() + ": " + self.value
@@ -564,18 +545,13 @@ class CSPPolicy(object):
         :param banned_directives: list of banned directives (see meta tag)
         :return: True if initialization was success, otherwise False 
         """
-        self.syntax_errors = []
         string_policy = csp_value.strip()
         if not string_policy:
             return False
-        self.directives = self._parse_policy(string_policy, banned_directives)
-        if len(self.directives):
+        if self._parse_policy(string_policy, banned_directives):
             self.value = csp_value
             return True
         else:
-            self.syntax_errors.append(
-                    CSPVulnerability(self.vuln_syntax_tpl % csp_value, 
-                        severity.HIGH, 'syntax', ''))
             return False
 
     def init_from_header(self, header_name, header_value):
@@ -606,7 +582,7 @@ class CSPPolicy(object):
             "object-src", "img-src", "media-src",
             "frame-src", "font-src", "connect-src", 
             "report-uri", "base-uri", "child-src", 
-            "style-src"
+            "style-src", "form-action", "frame-ancestors",
             ]
         directive = None
         dname = directive_name.lower()
@@ -617,15 +593,11 @@ class CSPPolicy(object):
             directive.strictness = self.default_src_strictness
         elif "script-src" == dname:
             directive = ScriptSrcDirective()
-        elif "frame-ancestors" == dname:
-            directive = FrameAncestorsDirective()
-        elif "form-action" == dname:
-            directive = FormActionDirective()
         elif "sandbox" == dname:
             directive = SandboxDirective()
         elif "plugin-types" == dname:
             directive = PluginTypesDirective()
-        
+       
         if directive:
             directive.source_limit = self.source_limit
             directive.trusted_hosts = self.trusted_hosts
@@ -636,16 +608,17 @@ class CSPPolicy(object):
 
     def _parse_policy(self, string_policy, banned_directives=[]):
         """
-        Parse CSP policy.
+        Parse CSP policy and set list of directives.
         See also https://www.w3.org/TR/CSP/#policy-parsing
 
         :param string_policy: string value of policy
         :param banned_directives: list of banned directives (see meta tag)
-        :return: result list of directives
+        :return: True on success parsing
         """
+        self.syntax_errors = []
         result = []
         tokens = [d.strip() for d in string_policy.strip().split(";")]
-        tokens = filter(lambda x:x.strip(), tokens)
+        tokens = filter(lambda x: x.strip(), tokens)
 
         for t in tokens:
             directive_name = t
@@ -658,22 +631,29 @@ class CSPPolicy(object):
 
             if directive_name in banned_directives:
                 continue
-            
+           
             directive = self.make_directive(directive_name)
             # CSP syntax error
             if not directive:
-                return []
+                self.syntax_errors.append(
+                        CSPVulnerability(self.vuln_parse_directive_tpl % directive_name,
+                                         severity.HIGH, 'syntax', ''))
+                continue
             if directive not in result:
                 if directive.init_value(directive_value):
                     result.append(directive)
-        return result
+        if result:
+            self.directives = result
+            return True
+        else:
+            return False
 
     def get_directive_by_name(self, directive_name):
         """
         Get directive by name.
 
         :param directive_name: name of directive
-        :return: directive if it exists in the policy, otherwise None 
+        :return: directive if it exists in the policy, otherwise None
         """
         for d in self.directives:
             if d.name.lower() == directive_name.lower():
@@ -688,15 +668,27 @@ class CSPPolicy(object):
         """
         vulns = []
         for d in self.directives:
-            d_vulns  = d.find_vulns()
+            d_vulns = d.find_vulns()
             if d_vulns:
                 vulns.extend(d_vulns)
+        # Check if report-uri exists
         if self.report_no_report_uri and not self.get_report_uri():
-            vulns.append(CSPVulnerability(self.vuln_no_report_uri_tpl, 
-                severity.LOW, 'reporting', ''))
-         
+            vulns.append(CSPVulnerability(self.vuln_no_report_uri_tpl,
+                         severity.LOW, 'reporting', ''))
+        # Check directives which does not fall back to the default sources
+        if self.report_not_fallback:
+            for d in ['frame-ancestors', 'form-action', 'base-uri']:
+                if not self.get_directive_by_name(d):
+                    vuln = CSPVulnerability(self.vuln_required_tpl % d, severity.MEDIUM,
+                                            'required', d)
+                    vulns.append(vuln)
+        # Check default-src
+        if not self.get_directive_by_name('default-src'):
+            vuln = CSPVulnerability(self.vuln_default_tpl, severity.MEDIUM,
+                                    'default_required', 'default-src')
+            vulns.append(vuln)
         return vulns + self.syntax_errors
-    
+   
     def find_vulns_by_directive(self, directive_name):
         """
         Find all vulnerabilities filtered by directive.
@@ -717,7 +709,7 @@ class CSPPolicy(object):
         :return: report uri, otherwise None
         """
         report_uri = self.get_directive_by_name('report-uri')
-        
+       
         if report_uri:
             return report_uri.value
         else:
@@ -727,7 +719,7 @@ class CSPPolicy(object):
         """
         Check if policy protects against XSS.
         See also https://www.w3.org/TR/CSP/#directives
-        
+       
         :return: True if protects, otherwise False
         """
         if not self.directives or self.report_only:
@@ -739,7 +731,7 @@ class CSPPolicy(object):
         default_src = self.get_directive_by_name('default-src')
 
         # must be enabled default_src or **all** risky directives
-        if not (default_src or \
+        if not (default_src or
                 reduce(lambda x, y: x and y, risky_directives)):
             return False
 
@@ -752,7 +744,7 @@ class CSPPolicy(object):
 
     def unsafe_inline_enabled(self):
         """
-        Check if there is 'unsafe-inline' keyword in source list of 
+        Check if there is 'unsafe-inline' keyword in source list of
         script-src and style-src directives.
 
         :return: True if there is 'unsafe-inline' in source list of risky directives
@@ -773,7 +765,8 @@ class CSPPolicy(object):
         for d in self.directives:
             result.extend(d.get_nonces_hashes(nonces=True, hashes=False))
         return result
-  
+ 
+
 class CSP(object):
     """Content Security Policy Level 2
     https://www.w3.org/TR/CSP/"""
@@ -785,6 +778,7 @@ class CSP(object):
     report_eval = True
     report_no_report_uri = False
     default_src_strictness = 0
+    report_not_fallback = False
 
     def header_provides_csp(self, header_name):
         """
@@ -804,7 +798,7 @@ class CSP(object):
         """
         Retrieve policy from meta tag.
         See also https://www.w3.org/TR/CSP/#delivery-html-meta-element
-        
+       
         :param response: HTTP response
         :return: list of policies
         """
@@ -833,9 +827,10 @@ class CSP(object):
             csp.report_eval = self.report_eval
             csp.report_no_report_uri = self.report_no_report_uri
             csp.default_src_strictness = self.default_src_strictness
+            csp.report_not_fallback = self.report_not_fallback
             if csp.init_value(csp_value, banned_directives=banned):
                 result.append(csp)
-         
+        
         return result
 
     def init_from_response(self, response):
@@ -846,8 +841,8 @@ class CSP(object):
         :return: list of policies
         """
         # TODO
-        # Merge multiple policies 
-        # https://www.w3.org/TR/CSP/#enforcing-multiple-policies 
+        # Merge multiple policies
+        # https://www.w3.org/TR/CSP/#enforcing-multiple-policies
         self.policies = []
         # From headers
         headers = response.get_headers()
@@ -859,6 +854,7 @@ class CSP(object):
                 csp.report_eval = self.report_eval
                 csp.report_no_report_uri = self.report_no_report_uri
                 csp.default_src_strictness = self.default_src_strictness
+                csp.report_not_fallback = self.report_not_fallback
                 if csp.init_from_header(header_name, headers[header_name]):
                     self.policies.append(csp)
         # From meta tag
@@ -874,7 +870,7 @@ class CSP(object):
         """
         Check if policies protect against XSS.
         See also https://www.w3.org/TR/CSP/#directives
-        
+       
         :return: True if at least one of policies protects, otherwise False
         """
         for policy in self.policies:
@@ -883,7 +879,7 @@ class CSP(object):
         return False
 
     def __str__(self):
-        return '|'.join([p.value for p in self.policies]) 
+        return '|'.join([p.value for p in self.policies])
 
     def __hash__(self):
         return hash(str(self))
@@ -902,10 +898,10 @@ class CSP(object):
             for nonce in policy.get_nonces():
                 result.add(nonce)
         return result
- 
+
     def find_nonce_vulns(self, csps):
         """
-        Find cases when nonces in source list of CSP 
+        Find cases when nonces in source list of CSP
         policy directives are not random in responses.
 
         :return: list of vulns
@@ -929,7 +925,7 @@ class CSP(object):
                 # Get intersection between nonces of policies!
                 if nonces:
                     vulns.append(CSPVulnerability(
-                        self.vuln_nonce_intersection_tpl % ", ".join(nonces), 
+                        self.vuln_nonce_intersection_tpl % ", ".join(nonces),
                         severity.HIGH, 'nonce_intersection', ''))
                     return vulns
             prev = policy

--- a/w3af/plugins/audit/xss.py
+++ b/w3af/plugins/audit/xss.py
@@ -24,7 +24,7 @@ import w3af.core.data.kb.knowledge_base as kb
 import w3af.core.data.constants.severity as severity
 
 from w3af.core.controllers.plugins.audit_plugin import AuditPlugin
-from w3af.core.controllers.csp.utils import site_protected_against_xss_by_csp
+from w3af.core.controllers.csp.utils import CSP
 
 from w3af.core.data.kb.vuln import Vuln
 from w3af.core.data.db.disk_list import DiskList
@@ -35,46 +35,19 @@ from w3af.core.data.options.option_list import OptionList
 from w3af.core.data.context.context import get_context_iter
 
 
-RANDOMIZE = 'RANDOMIZE'
-
-
 class xss(AuditPlugin):
     """
     Identify cross site scripting vulnerabilities.
     
-    :author: Andres Riancho (andres.riancho@gmail.com)
-    :author: Taras (oxdef@oxdef.info)
+    :author: Andres Riancho ( andres.riancho@gmail.com )
+    :author: Taras ( oxdef@oxdef.info )
     """
-    # TODO: Reduce the number of payloads by concatenating similar/related ones
-    PAYLOADS = [
-        # Start a new tag
-        '<',
-
-        # Escape HTML comments
-        '-->',
-
-        # Escape JavaScript multi line and CSS comments
-        '*/',
-
-        # Escapes for CSS
-        '*/:("\'',
-
-        # The ":" is useful in cases where we want to add the javascript
-        # protocol like <a href="PAYLOAD">   -->   <a href="javascript:alert()">
-        ':',
-
-        # Escape single line comments in JavaScript
-        "\n",
-
-        # Escape the HTML attribute value string delimiter
-        '"',
-        "'",
-        "`",
-
-        # Escape HTML attribute values without string delimiters
-        " =",
-    ]
-    PAYLOADS = ['%s%s%s' % (RANDOMIZE, p, RANDOMIZE) for p in PAYLOADS]
+    PAYLOADS = ['RANDOMIZE</->',
+                'RANDOMIZE/*',
+                'RANDOMIZE"RANDOMIZE',
+                "RANDOMIZE'RANDOMIZE",
+                "RANDOMIZE`RANDOMIZE",
+                "RANDOMIZE ="]
         
     def __init__(self):
         AuditPlugin.__init__(self)
@@ -114,11 +87,13 @@ class xss(AuditPlugin):
         
         :return: None
         """
-        csp_protects = site_protected_against_xss_by_csp(response)
+        csp = CSP()
+        csp.init_from_response(response)
+        csp_protects = csp.protects_against_xss()
         vuln_severity = severity.LOW if csp_protects else severity.MEDIUM
         
         desc = 'A Cross Site Scripting vulnerability was found at: %s'
-        desc %= mutant.found_at()
+        desc = desc % mutant.found_at()
         
         if csp_protects:
             desc += ('The risk associated with this vulnerability was lowered'
@@ -151,17 +126,7 @@ class xss(AuditPlugin):
         # Add data for the persistent xss checking
         if self._check_persistent_xss:
             self._xss_mutants.append((trivial_mutant, response.id))
-
-        # This is something I've seen in as a false positive during my
-        # assessments and is better explained in this stackoverflow question
-        # https://goo.gl/BgXVJY
-        ct_options, _ = response.get_headers().iget('X-Content-Type-Options')
-        content_type, _ = response.get_headers().iget('Content-Type')
-
-        if content_type == 'application/json' and ct_options == 'nosniff':
-            # No luck exploiting this JSON XSS
-            return False
-
+        
         if payload in response.get_body().lower():
             self._report_vuln(mutant, response, payload)
             return True
@@ -173,7 +138,7 @@ class xss(AuditPlugin):
         Analyze the mutant for reflected XSS.
         
         @parameter mutant: A mutant that was used to test if the parameter
-                           was echoed back or not
+            was echoed back or not
         """
         xss_strings = [replace_randomize(i) for i in self.PAYLOADS]
         fuzzable_params = [mutant.get_token_name()]
@@ -203,12 +168,11 @@ class xss(AuditPlugin):
             
             sent_payload = mutant.get_token_payload()
 
-            # TODO: https://github.com/andresriancho/w3af/issues/12305
             body_lower = response.get_body().lower()
             sent_payload_lower = sent_payload.lower()
 
             for context in get_context_iter(body_lower, sent_payload_lower):
-                if context.is_executable() or context.can_break():
+                if context.is_executable() or context.can_break(sent_payload_lower):
                     self._report_vuln(mutant, response, sent_payload)
                     return
 
@@ -247,17 +211,18 @@ class xss(AuditPlugin):
         
         :return: None, Vuln (if any) are saved to the kb.
         """
-        body = response.get_body()
-
+        body_lower = response.get_body().lower()
+        
         for mutant, mutant_response_id in self._xss_mutants:
 
             sent_payload = mutant.get_token_payload()
+            sent_payload_lower = sent_payload.lower()
 
-            for context in get_context_iter(body, sent_payload):
-                if context.is_executable() or context.can_break():
+            for context in get_context_iter(body_lower, sent_payload):
+                if context.is_executable() or context.can_break(sent_payload_lower):
                     self._report_persistent_vuln(mutant, response,
                                                  mutant_response_id,
-                                                 sent_payload,
+                                                 sent_payload_lower,
                                                  fuzzable_request)
                     break
     
@@ -271,21 +236,23 @@ class xss(AuditPlugin):
         response_ids = [response.id, mutant_response_id]
         name = 'Persistent Cross-Site Scripting vulnerability'
         
-        desc = ('A persistent Cross Site Scripting vulnerability'
-                ' was found by sending "%s" to the "%s" parameter'
-                ' at %s, which is echoed when browsing to %s.')
-        desc %= (mod_value, mutant.get_token_name(), mutant.get_url(),
-                 response.get_url())
+        desc = 'A persistent Cross Site Scripting vulnerability'\
+               ' was found by sending "%s" to the "%s" parameter'\
+               ' at %s, which is echoed when browsing to %s.'
+        desc = desc % (mod_value, mutant.get_token_name(), mutant.get_url(),
+                       response.get_url())
         
-        csp_protects = site_protected_against_xss_by_csp(response)
+        csp = CSP()
+        csp.init_from_response(response)
+        csp_protects = csp.protects_against_xss()
         vuln_severity = severity.MEDIUM if csp_protects else severity.HIGH
         
         if csp_protects:
-            desc += ('The risk associated with this vulnerability was lowered'
-                     ' because the site correctly implements CSP. The'
-                     ' vulnerability is still a risk for the application since'
-                     ' only the latest versions of some browsers implement CSP'
-                     ' checking.')
+            desc += 'The risk associated with this vulnerability was lowered'\
+                    ' because the site correctly implements CSP. The'\
+                    ' vulnerability is still a risk for the application since'\
+                    ' only the latest versions of some browsers implement CSP'\
+                    ' checking.'
                     
         v = Vuln.from_mutant(name, desc, vuln_severity,
                              response_ids, self.get_name(),
@@ -306,9 +273,9 @@ class xss(AuditPlugin):
         ol = OptionList()
         
         d1 = 'Identify persistent cross site scripting vulnerabilities'
-        h1 = ('If set to True, w3af will navigate all pages of the target one'
-              ' more time, searching for persistent cross site scripting'
-              ' vulnerabilities.')
+        h1 = 'If set to True, w3af will navigate all pages of the target one'\
+             ' more time, searching for persistent cross site scripting'\
+             ' vulnerabilities.'
         o1 = opt_factory('persistent_xss', self._check_persistent_xss, d1,
                          'boolean', help=h1)
         ol.add(o1)
@@ -346,4 +313,4 @@ class xss(AuditPlugin):
 
 def replace_randomize(data):
     rand_str = rand_alnum(5).lower()
-    return data.replace(RANDOMIZE, rand_str)
+    return data.replace("RANDOMIZE", rand_str)

--- a/w3af/plugins/grep/csp.py
+++ b/w3af/plugins/grep/csp.py
@@ -103,12 +103,17 @@ class csp(GrepPlugin):
         """
         ol = OptionList()
 
-        d = 'Maximum number of sources in source list'
-        o = opt_factory('source_limit', self._source_limit, d, 'integer')
+        d = 'Maximum number limit of sources in source list of directive'
+        h = ('The plugin will report a vulnerability when detects '
+        'that number of sources in source list of any directive '
+        'is bigger then this limit.')
+        o = opt_factory('source_limit', self._source_limit, d, 'integer', help=h)
         ol.add(o)
 
-        d = 'Trusted hosts for finding untrusted ones in source list'
-        o = opt_factory('trusted_hosts', self._trusted_hosts, d, 'list')
+        d = 'List of trusted hosts for finding untrusted ones in source list of directive'
+        h = ('The plugin will report a vulnerability when detects '
+        'that source list of any directive consists of ones from the list')
+        o = opt_factory('trusted_hosts', self._trusted_hosts, d, 'list', help=h)
         ol.add(o)
 
         return ol
@@ -177,5 +182,5 @@ There were found URL without CSP. Please, review it:
 """
 
     vuln_no_csp_tpl = """
-    The whole target has no CSP protection.
+The whole target has no CSP protection.
 """

--- a/w3af/plugins/grep/csp.py
+++ b/w3af/plugins/grep/csp.py
@@ -26,6 +26,7 @@ from w3af.core.data.options.option_list import OptionList
 from w3af.core.controllers.csp.utils import CSP
 from w3af.core.data.kb.vuln import Vuln
 
+
 class csp(GrepPlugin):
     """
     Identifies incorrect or too permissive Content Security Policy headers.
@@ -36,6 +37,7 @@ class csp(GrepPlugin):
     _report_eval = True
     _report_no_report_uri = False
     _default_src_strictness = 0
+    _report_not_fallback = False
     
     def __init__(self):
         """
@@ -65,6 +67,7 @@ class csp(GrepPlugin):
         csp.report_eval = self._report_eval
         csp.report_no_report_uri = self._report_no_report_uri
         csp.default_src_strictness = self._default_src_strictness
+        csp.report_not_fallback = self._report_not_fallback
 
         if csp.init_from_response(response): 
             self.csps.add(csp)
@@ -162,6 +165,12 @@ class csp(GrepPlugin):
         o = opt_factory('default_src_strictness', self._default_src_strictness, d, 'integer', help=h)
         ol.add(o)
 
+        d = 'Report about absent directives which do not fall back to the default sources'
+        h = ("The plugin will report a vulnerability when don't find directive from the list: "
+        "base-uri, form-action, frame-ancestors. These directives do not fall back to the default sources")
+        o = opt_factory('report_not_fallback', self._report_not_fallback, d, 'boolean', help=h)
+        ol.add(o)
+
         return ol
 
     def set_options(self, option_list):
@@ -178,6 +187,7 @@ class csp(GrepPlugin):
         self._report_eval = option_list['report_eval'].get_value()
         self._report_no_report_uri = option_list['report_no_report_uri'].get_value()
         self._default_src_strictness = option_list['default_src_strictness'].get_value()
+        self._report_not_fallback = option_list['report_not_fallback'].get_value()
 
     def get_long_desc(self):
         """

--- a/w3af/plugins/grep/csp.py
+++ b/w3af/plugins/grep/csp.py
@@ -35,6 +35,7 @@ class csp(GrepPlugin):
     _source_limit = 10
     _report_eval = True
     _report_no_report_uri = False
+    _default_src_strictness = 0
     
     def __init__(self):
         """
@@ -63,6 +64,8 @@ class csp(GrepPlugin):
         csp.trusted_hosts = self._trusted_hosts
         csp.report_eval = self._report_eval
         csp.report_no_report_uri = self._report_no_report_uri
+        csp.default_src_strictness = self._default_src_strictness
+
         if csp.init_from_response(response): 
             self.csps.add(csp)
             if len(self.csp_cache) < csp_cache_limit:
@@ -152,6 +155,13 @@ class csp(GrepPlugin):
         o = opt_factory('report_no_report_uri', self._report_no_report_uri, d, 'boolean', help=h)
         ol.add(o)
 
+        d = 'Default-src level of strictness'
+        h = ('The plugin will report a vulnerability when detects '
+        'that default-src value conflicts with level of strictness for this directive '
+        "0 is for level without restrictions, 1 permits only 'self' value and 2 is for only 'none' value")
+        o = opt_factory('default_src_strictness', self._default_src_strictness, d, 'integer', help=h)
+        ol.add(o)
+
         return ol
 
     def set_options(self, option_list):
@@ -167,6 +177,7 @@ class csp(GrepPlugin):
         self._trusted_hosts = option_list['trusted_hosts'].get_value()
         self._report_eval = option_list['report_eval'].get_value()
         self._report_no_report_uri = option_list['report_no_report_uri'].get_value()
+        self._default_src_strictness = option_list['default_src_strictness'].get_value()
 
     def get_long_desc(self):
         """

--- a/w3af/plugins/grep/csp.py
+++ b/w3af/plugins/grep/csp.py
@@ -110,7 +110,7 @@ class csp(GrepPlugin):
         if self._responses_without_csp:
             csp_vulns_detected = True
             result += self.vuln_without_tpl % "\n".join(
-                    [r[1] for r in self._responses_without_csp])
+                    [str(r[1]) for r in self._responses_without_csp])
         
         # Try to find weak nonces
         if len(self.csp_cache) > 1:
@@ -236,7 +236,7 @@ Issues
     vuln_without_tpl = """
 There were found URL without CSP. Please, review it:
 
-    %s
+%s
 """
 
     vuln_no_csp_tpl = """


### PR DESCRIPTION
1. Re-factored CSP module: from functions to OOP (directive->policy->holder of policies) Now much easier to maintain the code and add new functionality 
2. Added retrieval of CSP policy from meta tag
3. Added new checks
4. Removed related to not standard  CSP realization. Now only modern CSPv2
5. Updated tests
