### PR TITLE
Update installation command for Fedora.

### DIFF
--- a/w3af/core/controllers/dependency_check/platforms/fedora.py
+++ b/w3af/core/controllers/dependency_check/platforms/fedora.py
@@ -28,7 +28,7 @@ from ..requirements import CORE, GUI
 
 class Fedora(Platform):
     SYSTEM_NAME = 'fedora'
-    PKG_MANAGER_CMD = 'sudo yum install'
+    PKG_MANAGER_CMD = 'sudo dnf install'
     PIP_CMD = 'python-pip'
 
     CORE_SYSTEM_PACKAGES = ['python-pip', 'python-devel', 'python-setuptools',


### PR DESCRIPTION
Fedora now uses `dnf` instead of the `yum` command to install packages.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/andresriancho/w3af/13814)

<!-- Reviewable:end -->
