### PR TITLE
New Dockerfile and docker build scripts

### DIFF
--- a/extras/docker/Dockerfile
+++ b/extras/docker/Dockerfile
@@ -1,92 +1,21 @@
-# w3af.org
-# https://github.com/andresriancho/w3af/tree/master/extras
+FROM ubuntu:14.04
 
-FROM ubuntu:12.04
-MAINTAINER Andres Riancho <andres.riancho@gmail.com>
+ADD . /w3af
+RUN apt-get update && apt-get upgrade -y && \
+    /bin/bash /w3af/add_user.sh && \
+    /bin/bash /w3af/install.sh && \
+    /bin/bash /w3af/cleanup.sh
 
-# Initial setup
-RUN mkdir /home/w3af
-WORKDIR /home/w3af
-ENV HOME /home/w3af
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LOGNAME w3af
-# Squash errors about "Falling back to ..." during package installation
-ENV TERM linux
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+USER app
+ENV PATH /home/app/w3af:$PATH 
+WORKDIR /home/app
 
-# Update before installing any package
-RUN apt-get update -y
-RUN apt-get upgrade -y
-RUN apt-get dist-upgrade -y
+CMD["w3af_api","w3af_console","w3af_gui"]
 
-# Install basic and GUI requirements, python-lxml because it doesn't compile correctly from pip
-RUN apt-get install -y python-pip build-essential libxslt1-dev libxml2-dev libsqlite3-dev \
-                       libyaml-dev openssh-server python-dev git python-lxml wget libssl-dev \
-                       xdot python-gtk2 python-gtksourceview2 ubuntu-artwork dmz-cursor-theme \
-                       ca-certificates libffi-dev
+EXPOSE 5000,44449,44444
 
-# Add the w3af user
-# TODO - actually use the w3af user instead of running everything as root
-RUN useradd w3af
-
-# Get ssh package ready
-RUN mkdir /var/run/sshd
-RUN echo 'root:w3af' | chpasswd
-RUN mkdir /home/w3af/.ssh/
-RUN echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDjXxcHjyVkwHT+dSYwS3vxhQxZAit6uZAFhuzA/dQ2vFu6jmPk1ewMGIYVO5D7xV3fo7/RXeCARzqHl6drw18gaxDoBG3ERI6LxVspIQYjDt5Vsqd1Lv++Jzyp/wkXDdAdioLTJyOerw7SOmznxqDj1QMPCQni4yhrE+pYH4XKxNx5SwxZTPgQWnQS7dasY23bv55OPgztI6KJzZidMEzzJVKBXHy1Ru/jjhmWBghiXYU5RBDLDYyT8gAoWedYgzVDmMZelLR6Y6ggNLOtMGiGYfPWDUz9Z6iDAUsOQBtCJy8Sj8RwSQNpmOgSzBanqnhed14hLwdYhnKWcPNMry71 w3af@w3af-docker.org' > /home/w3af/.ssh/w3af-docker.pub
-RUN mkdir -p /root/.ssh/
-RUN cat /home/w3af/.ssh/w3af-docker.pub >> /root/.ssh/authorized_keys
-
-# Get and install pip
-RUN pip install --upgrade pip
-
+# Ports
 #
-# We install some pip packages before adding the code in order to better leverage
-# the docker cache
-#
-# Leave one library without install, so w3af_dependency_install is actually
-# created and we can run the next commands without if statements
-#
-#tblib==0.2.0
-#
-RUN pip install clamd==1.0.1 PyGithub==1.21.0 GitPython==0.3.2.RC1 pybloomfiltermmap==0.3.14 \
-        esmre==0.3.1 phply==0.9.1 nltk==3.0.1 chardet==2.1.1 pdfminer==20140328 \
-        futures==2.1.5 pyOpenSSL==0.15.1 scapy-real==2.2.0-dev guess-language==0.2 cluster==1.1.1b3 \
-        msgpack-python==0.4.4 python-ntlm==1.0.1 halberd==0.2.4 darts.util.lru==0.5 \
-        ndg-httpsclient==0.3.3 pyasn1==0.1.7 Jinja2==2.7.3 \
-        vulndb==0.0.17 markdown==2.6.1 psutil==2.2.1 mitmproxy==0.12.1 \
-        ruamel.ordereddict==0.4.8 Flask==0.10.1 PyYAML==3.11
-
-# Install w3af
-ADD . /home/w3af/w3af
-WORKDIR /home/w3af/w3af
-RUN ./w3af_console ; true
-
-# Change the install script to add the -y and not require input
-RUN sed 's/sudo //g' -i /tmp/w3af_dependency_install.sh
-RUN sed 's/apt-get/apt-get -y/g' -i /tmp/w3af_dependency_install.sh
-RUN sed 's/pip install/pip install --upgrade/g' -i /tmp/w3af_dependency_install.sh
-
-# Run the dependency installer
-RUN /tmp/w3af_dependency_install.sh
-
-# Run the dependency installer
-RUN ./w3af_gui ; true
-RUN sed 's/sudo //g' -i /tmp/w3af_dependency_install.sh
-RUN sed 's/apt-get/apt-get -y/g' -i /tmp/w3af_dependency_install.sh
-RUN sed 's/pip install/pip install --upgrade/g' -i /tmp/w3af_dependency_install.sh
-RUN /tmp/w3af_dependency_install.sh
-
-# Compile the py files into pyc in order to speed-up w3af's start
-RUN python -m compileall -q .
-
-# Cleanup to make the image smaller
-RUN rm /tmp/w3af_dependency_install.sh
-RUN apt-get clean
-RUN rm -rf /var/lib/apt/lists/*
-RUN rm -rf /tmp/pip-build-root
-
-EXPOSE 22
-
-CMD ["/usr/sbin/sshd", "-D"]
+# 5000  => API
+# 44449 => RFI Plugin
+# 44444 => ?

--- a/extras/docker/Dockerfile
+++ b/extras/docker/Dockerfile
@@ -1,4 +1,8 @@
+# w3af.org
+# https://github.com/andresriancho/w3af/tree/master/extras
+
 FROM ubuntu:14.04
+MAINTAINER Andres Riancho <andres.riancho@gmail.com>
 
 ADD . /w3af
 RUN apt-get update && apt-get upgrade -y && \

--- a/extras/docker/add_user.sh
+++ b/extras/docker/add_user.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+## Create a user for applications.
+addgroup --gid 9999 app
+adduser --uid 9999 --gid 9999 --disabled-password --gecos "Application" app
+usermod -L app

--- a/extras/docker/cleanup.sh
+++ b/extras/docker/cleanup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+apt-get clean
+
+rm -rf /w3af
+rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*

--- a/extras/docker/docker-build.sh
+++ b/extras/docker/docker-build.sh
@@ -5,6 +5,9 @@ set -e
 
 cp Dockerfile ../../
 cp .dockerignore ../../
+cp install.sh ../../
+cp cleanup.sh ../../
+cp add_user.sh ../../
 
 cd ../../
 
@@ -27,6 +30,7 @@ docker push andresriancho/w3af:${NEW_TAG}
 
 rm -rf Dockerfile
 rm -rf .dockerignore
+rm -f install.sh cleanup.sh add_user.sh
 
 cd extras/docker/
 

--- a/extras/docker/install.sh
+++ b/extras/docker/install.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+export LC_ALL=C
+install='apt-get install -y --no-install-recommends'
+
+# Remove warnings regarding 'no frontend dialog'
+echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+# Install python
+$install python-pip build-essential libxslt1-dev libxml2-dev libsqlite3-dev \
+           libyaml-dev openssh-server python-dev git python-lxml wget libssl-dev \
+           xdot python-gtk2 python-gtksourceview2 ubuntu-artwork dmz-cursor-theme \
+           ca-certificates libffi-dev libjpeg-dev libjpeg8-dev
+
+# Get and install pip
+pip install --upgrade pip
+
+cd /home/app/
+git clone --depth 1 https://github.com/andresriancho/w3af.git w3af
+cd /home/app/w3af
+
+set +e
+./w3af_console
+set -e
+
+# Change the install script to add the -y and not require input
+sed 's/sudo //g' -i /tmp/w3af_dependency_install.sh
+sed 's/apt-get/apt-get -y/g' -i /tmp/w3af_dependency_install.sh
+sed 's/pip install/pip install --upgrade/g' -i /tmp/w3af_dependency_install.sh
+
+chmod +x /tmp/w3af_dependency_install.sh
+/tmp/w3af_dependency_install.sh
+
+# Compile the py files into pyc in order to speed-up w3af's start
+python -m compileall .
+chown -R app /home/app/w3af
+
+# accept terms [because first run will get stuck otherwise]
+if [ -f /home/app/.w3af/startup.conf ]
+then
+    if ! grep -i "^accepted-disclaimer = true$" /home/app/.w3af/startup.conf
+    then
+        echo "accepted-disclaimer = true" >> /home/app/.w3af/startup.conf
+    fi
+else
+    if [ ! -d /home/app/.w3af ]
+    then
+        mkdir /home/app/.w3af
+    fi
+    echo "[STARTUP_CONFIG]" >> /home/app/.w3af/startup.conf
+    echo "auto-update = true" >> /home/app/.w3af/startup.conf
+    echo "frequency = D" >> /home/app/.w3af/startup.conf
+    echo "accepted-disclaimer = true" >> /home/app/.w3af/startup.conf
+    chown -R app.app /home/app/.w3af
+fi
+
+# clean
+rm -rf /tmp/pip-build-root /tmp/w3af_dependency_install.sh


### PR DESCRIPTION
Changes:

1) Fixes Issue [8461](https://github.com/andresriancho/w3af/issues/8461) -- at least through bash command line
2) W3af now runs using the user "app" instead of "root" inside docker container
3) The new Dockerfile exposes w3af_console, w3af_api and w3af_gui

> When the user runs ./w3af_console_docker it would be awesome to be able to forward command line parameters to the container command. When this is done the following command:  
> ./w3af_console_docker -s ~/w3af-shared/foo.w3af  
> Should output the same as:  
> ./w3af_console -s ~/w3af-shared/foo.w3af

It's now possible to call w3af_console like this:

`docker run --name w3af --rm -it -v /root/:/tmp andres/w3af w3af_console -s /tmp/script.w3af`

P.S.: Supposing that your `script.w3af` is located at `/root/script.w3af` in the host machine.
# 

More on interacting with W3af docker container:

Access container's bash: `docker exec -it w3af /bin/bash`
Check if w3af is running: `docker top w3af`
View w3af output: `docker logs w3af`
Get w3af's info (including IP Address): `docker inspect w3af`
Get w3af's IP address alone: `docker inspect -f '{{ .NetworkSettings.IPAddress }}' w3af`
# 

Note: W3af image is around 750 MB in size. It's ok I suppose. OpenVAS is 3.5GB and Owasp ZAP 1.5GB. W3af size is good then :)

Note: I've followed [Contributing 101](https://github.com/andresriancho/w3af/wiki/Contributing-101) but the pull request to master wasn't going to work as the "git branch" command copies the "origin/development" so here I am, making a pull request to "origin/development" :)
# 

What's missing (that I can tell so far):
- Didn't check if EXPOSE matches all necessary ports for w3af to run
- Didn't check how to run W3AF GUI (forward X), but forward X as a port may be an EXPOSE entry too
- Didn't check if is necessary to modify any other python script. I focused on Dockerfile alone
- I forgot to add Andres as the maintainer, but can add. No problem :)
