### PR TITLE
Fix dependency_check

### DIFF
--- a/w3af/core/controllers/dependency_check/dependency_check.py
+++ b/w3af/core/controllers/dependency_check/dependency_check.py
@@ -78,8 +78,8 @@ def dependency_check(dependency_set=CORE, exit_on_failure=True):
                 if w3af_req_version == dist_version:
                     # It's installed and the version matches!
                     break
-        else:
-            failed_deps.append(w3af_req)
+                else:
+                    failed_deps.append(w3af_req)
 
     #
     #    Check for missing operating system packages


### PR DESCRIPTION
Wrong indent cause `dependency_check` error.
