### PR TITLE
Fix Fedora Dependency Errors

### DIFF
--- a/w3af/core/controllers/dependency_check/platforms/fedora.py
+++ b/w3af/core/controllers/dependency_check/platforms/fedora.py
@@ -31,9 +31,9 @@ class Fedora(Platform):
     PKG_MANAGER_CMD = 'sudo yum install'
     PIP_CMD = 'python-pip'
 
-    CORE_SYSTEM_PACKAGES = ['python-pip', 'python-devel', 'python-setuptools',
+    CORE_SYSTEM_PACKAGES = ['python-pip', 'python-devel', 'python2-setuptools',
                             'libsqlite3x-devel', 'git', 'libxml2-devel',
-                            'libxslt-devel', 'openssl-devel', 'libffi-devel']
+                            'libxslt-devel', 'openssl-devel', 'libffi-devel', 'gcc-c++']
 
     GUI_SYSTEM_PACKAGES = CORE_SYSTEM_PACKAGES[:]
     GUI_SYSTEM_PACKAGES.extend(['graphviz', 'pygtksourceview', 'pygtk2',


### PR DESCRIPTION
## This commit fix some dependency errors on Fedora Linux:

1. When checking for python-setuptools the actual package installed on fedora is not python-setuptools, actually when you run the command `yum/dnf install python-setuptools` the real package name is on rpm is python2-setuptools.

2. Another error is during pybloomfiltermmap compilation process because it requires the gcc-c++ package.