### PR TITLE
dont check signatures if the response is not 200 in crawl/find_backdoors

### DIFF
--- a/w3af/core/controllers/dependency_check/requirements.py
+++ b/w3af/core/controllers/dependency_check/requirements.py
@@ -27,7 +27,7 @@ GUI = 2
 
 CORE_PIP_PACKAGES = [PIPDependency('pyclamd', 'pyClamd', '0.3.15'),
                      PIPDependency('github', 'PyGithub', '1.21.0'),
-                     PIPDependency('git.util', 'GitPython', '0.3.2.RC1'),
+                     PIPDependency('git.util', 'GitPython', '2.1.1'),
                      PIPDependency('pybloomfilter', 'pybloomfiltermmap', '0.3.14'),
                      PIPDependency('esmre', 'esmre', '0.3.1'),
                      PIPDependency('phply', 'phply', '0.9.1'),


### PR DESCRIPTION
When tomcat (or most web servers I have worked with) returns a 404 it includes information from the request, as such this does not make a very interesting check if its a 404.

![image](https://cloud.githubusercontent.com/assets/3145127/21127558/c05fe9b8-c0a8-11e6-8fbe-4e5f3cb86f9f.png)

Origonally I decided to use a check that already exists to check if its a 404 and if so returns. but after thinking about it we should catch only 200s.