### PR TITLE
change package name libffi-devel for (open)Suse

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## w3af - Web application attack and audit framework
+## w3af - Web Application Attack and Audit Framework
 
 w3af is an [open source](https://www.gnu.org/licenses/gpl-2.0.txt) web 
 application security scanner which helps developers and penetration testers

--- a/doc/sphinx/advanced-install.rst
+++ b/doc/sphinx/advanced-install.rst
@@ -93,6 +93,30 @@ Or,
     (venv)$ . /tmp/w3af_dependency_install.sh
 
 
+
+If you use OpenSuse:
+
+.. code-block:: console
+
+    $ cd w3af
+    $ sudo zypper install python-gtksourceview python-gtk
+    $ virtualenv venv
+    $ mkdir -p venv/lib/python2.7/dist-packages/
+    $ cd venv/lib/python2.7/dist-packages/
+    $ ln -s /usr/lib64/python2.7/site-packages/glib/ glib
+    $ ln -s /usr/lib64/python2.7/site-packages/gobject/ gobject
+    $ ln -s /usr/lib64/python2.7/site-packages/gtk-2.0* gtk-2.0
+    $ ln -s /usr/lib64/python2.7/site-packages/pygtk.pth pygtk.pth
+    $ ln -s /usr/lib64/python2.7/site-packages/cairo cairo
+    $ ln -s /usr/lib64/python2.7/site-packages/webkit/ webkit
+    $ ln -s /usr/lib64/python2.7/site-packages/pygtk.pth pygtk.pth
+    $ ln -s /usr/lib64/python2.7/site-packages/gtksourceview2.so gtksourceview2.so
+    $ cd -
+    $ . venv/bin/activate
+    (venv)$ ./w3af_gui
+    (venv)$ . /tmp/w3af_dependency_install.sh
+
+
 Each time you want to run ``w3af`` in a new console you'll have to activate the
 virtualenv:
 

--- a/w3af/core/controllers/dependency_check/platforms/fedora.py
+++ b/w3af/core/controllers/dependency_check/platforms/fedora.py
@@ -31,7 +31,7 @@ class Fedora(Platform):
     PKG_MANAGER_CMD = 'sudo yum install'
     PIP_CMD = 'python-pip'
 
-    CORE_SYSTEM_PACKAGES = ['python-pip', 'python-devel', 'python-setuptools',
+    CORE_SYSTEM_PACKAGES = ['python-pip', 'python-devel', 'python2-setuptools',
                             'libsqlite3x-devel', 'git', 'libxml2-devel',
                             'libxslt-devel', 'openssl-devel', 'libffi-devel']
 

--- a/w3af/core/controllers/dependency_check/platforms/suse.py
+++ b/w3af/core/controllers/dependency_check/platforms/suse.py
@@ -33,7 +33,7 @@ class SuSE(Platform):
 
     CORE_SYSTEM_PACKAGES = ['python-pip', 'python-devel', 'sqlite3-devel',
                             'git', 'libxml2-devel', 'libxslt-devel',
-                            'python-webkitgtk', 'libffi-devel']
+                            'python-webkitgtk', 'libffi-devel-gcc5']
 
     GUI_SYSTEM_PACKAGES = CORE_SYSTEM_PACKAGES[:]
     GUI_SYSTEM_PACKAGES.extend(['graphviz', 'python-gtksourceview',

--- a/w3af/core/controllers/tests/pylint.rc
+++ b/w3af/core/controllers/tests/pylint.rc
@@ -36,7 +36,7 @@ enable=E0101,E1103,E1124,E0611,E1123,E1120,E0202,E0203,E0100,E1305,E0221,E0222,E
 # can either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once).
-#disable=
+disable=F0010
 
 [REPORTS]
 


### PR DESCRIPTION
package name libffi-devel in openSuse is libffi-devel-gcc5

also add documentation how to running w3af_gui on openSuse 42.2