### PR TITLE
Fix ldap error message pattern for PHP

### DIFF
--- a/w3af/plugins/audit/ldapi.py
+++ b/w3af/plugins/audit/ldapi.py
@@ -46,7 +46,7 @@ class ldapi(AuditPlugin):
         'com.sun.jndi.ldap',
 
         # PHP
-        'Search: Bad search filter',
+        'Bad search filter',
 
         # http://support.microsoft.com/kb/218185
         'Protocol error occurred',


### PR DESCRIPTION
Now ldapi audit plugin has `Search: Bad search filter` value in the list of possible error patterns. Manual fuzzing shows that sometimes output of scripts suspected to be vulnerable for LDAP injection do not have prefix `Search: ` on their LDAP error message.

Few examples:
- [SimpleLdap Drupal module error](https://www.drupal.org/node/1961782)
- [Roundcube](https://github.com/roundcube/roundcubemail/issues/4934)

I hope the plain "Bad search filter" won't bring any false positives.

Cheers