### PR TITLE
Adds a control to avoid auditing CSS and JS files

### DIFF
--- a/w3af/plugins/audit/csrf.py
+++ b/w3af/plugins/audit/csrf.py
@@ -70,7 +70,7 @@ class csrf(AuditPlugin):
 
         :param freq: A FuzzableRequest
         """
-        if not self._is_suitable(freq):
+        if not self._is_suitable(freq, orig_response):
             return
 
         # Referer / Origin check
@@ -112,7 +112,7 @@ class csrf(AuditPlugin):
 
         return True
 
-    def _is_suitable(self, freq):
+    def _is_suitable(self, freq, orig_response):
         """
         For CSRF attack we need request with payload and persistent/session
         cookies.
@@ -137,6 +137,11 @@ class csrf(AuditPlugin):
         if freq.get_method() == 'GET' and self._strict_mode:
             return False
 
+        # Do we need to audit CSS and JS files?
+        content_type = orig_response.get_headers().get('content-type', None)
+        if content_type in ('text/css', 'application/javascript'):
+            return False
+        
         # Does the request have a payload?
         #
         # By checking like this we're loosing the opportunity to find CSRF


### PR DESCRIPTION
Current csrf plugin audits CSS and JS files and results false positives.
I think "_is_suitable" method is the right place to check that. 
Please take a look and let me know what you think