### PR TITLE
Improvements on MS15-034

### DIFF
--- a/w3af/plugins/infrastructure/ms15_034.py
+++ b/w3af/plugins/infrastructure/ms15_034.py
@@ -20,10 +20,13 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 """
 import w3af.core.data.constants.severity as severity
+import w3af.core.controllers.output_manager as om
 
 from w3af.core.controllers.plugins.infrastructure_plugin import InfrastructurePlugin
+from w3af.core.controllers.exceptions import BaseFrameworkException
 from w3af.core.controllers.misc.decorators import runonce
 from w3af.core.controllers.exceptions import RunOnce
+from w3af.core.data.parsers import parser_cache
 from w3af.core.data.dc.headers import Headers
 from w3af.core.data.kb.vuln import Vuln
 
@@ -38,24 +41,59 @@ class ms15_034(InfrastructurePlugin):
     def discover(self, fuzzable_request):
         """
         Checks if the remote IIS is vulnerable to MS15-034
-        """
-        url = fuzzable_request.get_url()
-        headers = Headers([('Range', 'bytes=18-18446744073709551615')])
 
-        response = self._uri_opener.GET(url,
+        Request image files for better detection
+        """
+
+        image_urls = self._get_images(fuzzable_request)
+
+        for url in image_urls:
+
+            headers = Headers([('Range', 'bytes=0-18446744073709551615')])
+
+            response = self._uri_opener.GET(url,
                                         cache=False,
                                         grep=False,
                                         headers=headers)
 
-        if response.get_code() == 416:
-            desc = ('The target IIS web server is vulnerable to MS15-034 which'
+            if response.get_code() == 416:
+                desc = ('The target IIS web server is vulnerable to MS15-034 which'
                     ' allows remote code execution due to a flaw in HTTP.sys')
 
-            v = Vuln('MS15-034', desc, severity.HIGH, response.id,
+                v = Vuln('MS15-034', desc, severity.HIGH, response.id,
                      self.get_name())
-            v.set_url(response.get_url())
+                v.set_url(response.get_url())
 
-            self.kb_append_uniq(self, 'ms15_034', v)
+                self.kb_append_uniq(self, 'ms15_034', v)
+
+                break
+
+    def _get_images(self, fuzzable_request):
+        """
+        Get all img tags and retrieve the src list.
+
+        :param fuzzable_request: The request to modify
+        :return: A list with containing image sources
+        """
+        res = []
+
+        try:
+            response = self._uri_opener.GET(fuzzable_request.get_uri(),
+                                            cache=False)
+        except:
+            om.out.debug('Failed to retrieve the page for finding image sources.')
+        else:
+            try:
+                document_parser = parser_cache.dpc.get_document_parser_for(response)
+            except BaseFrameworkException:
+                return []
+
+            image_path_list = document_parser.get_references_of_tag('img')
+
+            for path in image_path_list:
+                res.append(path)
+
+        return res
 
     def get_long_desc(self):
         """
@@ -63,7 +101,7 @@ class ms15_034(InfrastructurePlugin):
         """
         return """
         Checks if the remote IIS is vulnerable to MS15-034 by sending one HTTP
-        request containing the `Range: bytes=18-18446744073709551615` header.
+        request containing the `Range: bytes=0-18446744073709551615` header.
 
         Warning: In some strange scenarios this test can cause a Denial of
         Service.


### PR DESCRIPTION
This PR  tries to address false-negatives and unintentional Denial of Service 

* Requesting non-image files might result false-negatives. Let's request image files for better detection.
>  "Requesting non-image files was hit-or-miss with the server often responding with a connection reset."
quoted from http://www.securitysift.com/an-analysis-of-ms15-034/

* Additionally bytes=18-18446744073709551615 as Range value most probably results DoS in vulnerable servers. Range with bytes=0-18446744073709551615 is more safer for detection.

Please let me know what do you think about this update?