### PR TITLE
Fixes zlib header check decompression exception

### DIFF
--- a/w3af/core/data/url/handlers/gzip_handler.py
+++ b/w3af/core/data/url/handlers/gzip_handler.py
@@ -57,7 +57,7 @@ class HTTPGzipProcessor(urllib2.BaseHandler):
                     data = gzip.GzipFile(fileobj=StringIO(body)).read()
                 elif "deflate" in enc_hdr:
                     body = response.read()
-                    data = zlib.decompress(body)
+                    data = zlib.decompress(body, -zlib.MAX_WBITS)
                 else:
                     data = response.read()
             except:


### PR DESCRIPTION
Some deflate targets which use a different zlib header triggers incorrect header check exceptions:

    Error -3 while decompressing data: incorrect header check