### PR TITLE
Adds RFC1951 uncompression when RFC1950 fails

### DIFF
--- a/w3af/core/data/url/handlers/gzip_handler.py
+++ b/w3af/core/data/url/handlers/gzip_handler.py
@@ -60,10 +60,16 @@ class HTTPGzipProcessor(urllib2.BaseHandler):
                     data = zlib.decompress(body)
                 else:
                     data = response.read()
-            except:
-                # I get here when the HTTP response body is corrupt
-                # return the same thing that I got... can't do magic yet!
-                return response
+            except Exception as e:
+                rfc1951 = "Error -3 while decompressing data: incorrect " \
+                          "header check"
+                if str(e) == rfc1951:
+                    # Body has been compressed per RFC 1951, not RFC 1950.
+                    data = zlib.decompress(body, -zlib.MAX_WBITS)
+                else:
+                    # I get here when the HTTP response body is corrupt
+                    # return the same thing that I got... can't do magic yet!
+                    return response
             else:
                 # The response was successfully unzipped
                 response.set_body(data)


### PR DESCRIPTION
Some deflate targets which use a different zlib header triggers incorrect header check exceptions:

   Error -3 while decompressing data: incorrect header check

Related discussion: https://github.com/andresriancho/w3af/pull/15711#pullrequestreview-43999001