### PR TITLE
Test on a more current Python 2

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ machine:
     - docker
 
   python:
-    version: 2.7.3
+    version: 2.7.13
 
   post:
     # This was required to avoid issues with different builds of python being


### PR DESCRIPTION
Do you consider to add [flake8](http://flake8.readthedocs.io) to the testing?  It seems quite confused by the underscores...

flake8 testing of https://github.com/andresriancho/w3af on Python 2.7.13

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./w3af/core/controllers/core_helpers/exception_handler.py:75:22: F821 undefined name '_'
                    (_, _, exception_data.traceback),
                     ^

./w3af/core/controllers/core_helpers/exception_handler.py:75:25: F821 undefined name '_'
                    (_, _, exception_data.traceback),
                        ^

./w3af/core/controllers/exception_handling/helpers.py:103:22: F821 undefined name '_'
    crash_dump.write(_('Submit this bug here:'
                     ^
__...__
```