### PR TITLE
fix Pebble version

### DIFF
--- a/w3af/core/controllers/dependency_check/requirements.py
+++ b/w3af/core/controllers/dependency_check/requirements.py
@@ -78,7 +78,7 @@ CORE_PIP_PACKAGES = [PIPDependency('pyclamd', 'pyClamd', '0.3.15'),
                      PIPDependency('tldextract', 'tldextract', '1.7.2'),
 
                      # pebble multiprocessing
-                     PIPDependency('pebble', 'pebble', '4.3.2'),
+                     PIPDependency('pebble', 'pebble', '4.3.3'),
                      ]
 
 GUI_PIP_EXTRAS = [PIPDependency('xdot', 'xdot', '0.6')]


### PR DESCRIPTION
pebble 4.3.2 throw error: (9, 'Bad file descriptor') on osx os when use global_redirect plugin (https://github.com/noxdafox/pebble/issues/10)