### PR TITLE
json_file - severity was duplicated, oops

### DIFF
--- a/w3af/plugins/output/json_file.py
+++ b/w3af/plugins/output/json_file.py
@@ -117,7 +117,6 @@ class json_file(OutputPlugin):
                         "WASC IDs": getattr(info, "wasc_ids", []),
                         "Tags": getattr(info, "tags", []),
                         "VulnDB ID": info.get_vulndb_id(),
-                        "Severity": info.get_severity(),
                         "Description": info.get_desc()}
                 items.append(item)
             except Exception, e:


### PR DESCRIPTION
a call to the severity attributed was duplicated. didn't affect output, but was unneeded. removed.