### PR TITLE
Updated Dockerfile, added Jenkinsfile.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,34 @@
+pipeline {
+  agent any
+
+  environment {
+    TAG = "REPOSITORY/IMAGE:TAG"
+  }
+
+  stages {
+    stage("Build") {
+      steps {
+        sh """
+           cp extras/docker/Dockerfile . && \
+           cp extras/docker/.dockerignore . && \
+           docker build -t ${TAG} .
+           """
+      }
+    }
+
+    stage("Push") {
+      steps {
+        sh "docker push ${TAG}"
+      }
+    }
+
+    stage("Cleanup") {
+      steps {
+        sh """
+           rm -rf Dockerfile && \
+           rm -rf .dockerignore
+           """
+      }
+    }
+  }
+}

--- a/extras/docker/Dockerfile
+++ b/extras/docker/Dockerfile
@@ -1,91 +1,121 @@
+#
 # w3af.org
 # https://github.com/andresriancho/w3af/tree/master/extras
+#
+FROM ubuntu:16.04
 
-FROM ubuntu:12.04
-MAINTAINER Andres Riancho <andres.riancho@gmail.com>
+#
+# Andres Riancho
+#
+LABEL maintainer="andres.riancho@gmail.com"
 
+#
 # Initial setup
-RUN mkdir /home/w3af
+#
 WORKDIR /home/w3af
-ENV HOME /home/w3af
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LOGNAME w3af
-# Squash errors about "Falling back to ..." during package installation
-ENV TERM linux
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+ENV HOME=/home/w3af \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LOGNAME=w3af \
+    LC_ALL=C \
+    #
+    # Squash errors about "Falling back to ..." during package installation
+    #
+    TERM=linux
 
-# Update before installing any package
-RUN apt-get update -y
-RUN apt-get upgrade -y
-RUN apt-get dist-upgrade -y
-
-# Install basic and GUI requirements, python-lxml because it doesn't compile correctly from pip
-RUN apt-get install -y python-pip build-essential libxslt1-dev libxml2-dev libsqlite3-dev \
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
+    #
+    # Update before installing any package
+    #
+    apt-get update -y && \
+    apt-get upgrade -y && \
+    apt-get dist-upgrade -y && \
+    #
+    # Install basic and GUI requirements, python-lxml because it doesn't compile correctly from pip
+    #
+    apt-get install -y python-pip build-essential libxslt1-dev libxml2-dev libsqlite3-dev \
                        libyaml-dev openssh-server python-dev git python-lxml wget libssl-dev \
                        xdot python-gtk2 python-gtksourceview2 ubuntu-artwork dmz-cursor-theme \
-                       ca-certificates libffi-dev
-
-# Add the w3af user
-# TODO - actually use the w3af user instead of running everything as root
-RUN useradd w3af
-
-# Get ssh package ready
-RUN mkdir /var/run/sshd
-RUN echo 'root:w3af' | chpasswd
-RUN mkdir /home/w3af/.ssh/
-RUN echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDjXxcHjyVkwHT+dSYwS3vxhQxZAit6uZAFhuzA/dQ2vFu6jmPk1ewMGIYVO5D7xV3fo7/RXeCARzqHl6drw18gaxDoBG3ERI6LxVspIQYjDt5Vsqd1Lv++Jzyp/wkXDdAdioLTJyOerw7SOmznxqDj1QMPCQni4yhrE+pYH4XKxNx5SwxZTPgQWnQS7dasY23bv55OPgztI6KJzZidMEzzJVKBXHy1Ru/jjhmWBghiXYU5RBDLDYyT8gAoWedYgzVDmMZelLR6Y6ggNLOtMGiGYfPWDUz9Z6iDAUsOQBtCJy8Sj8RwSQNpmOgSzBanqnhed14hLwdYhnKWcPNMry71 w3af@w3af-docker.org' > /home/w3af/.ssh/w3af-docker.pub
-RUN mkdir -p /root/.ssh/
-RUN cat /home/w3af/.ssh/w3af-docker.pub >> /root/.ssh/authorized_keys
-
-# Get and install pip
-RUN pip install --upgrade pip
+                       ca-certificates libffi-dev && \
+    #
+    # Add the w3af user
+    # TODO - actually use the w3af user instead of running everything as root
+    #
+    useradd w3af && \
+    #
+    # Get ssh package ready
+    #
+    mkdir /var/run/sshd && \
+    echo 'root:w3af' | chpasswd && \
+    mkdir /home/w3af/.ssh/ && \
+    echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDjXxcHjyVkwHT+dSYwS3vxhQxZAit6uZAFhuzA/dQ2vFu6jmPk1ewMGIYVO5D7xV3fo7/RXeCARzqHl6drw18gaxDoBG3ERI6LxVspIQYjDt5Vsqd1Lv++Jzyp/wkXDdAdioLTJyOerw7SOmznxqDj1QMPCQni4yhrE+pYH4XKxNx5SwxZTPgQWnQS7dasY23bv55OPgztI6KJzZidMEzzJVKBXHy1Ru/jjhmWBghiXYU5RBDLDYyT8gAoWedYgzVDmMZelLR6Y6ggNLOtMGiGYfPWDUz9Z6iDAUsOQBtCJy8Sj8RwSQNpmOgSzBanqnhed14hLwdYhnKWcPNMry71 w3af@w3af-docker.org' > /home/w3af/.ssh/w3af-docker.pub && \
+    mkdir -p /root/.ssh/ && \
+    cat /home/w3af/.ssh/w3af-docker.pub >> /root/.ssh/authorized_keys && \
+    #
+    # Get and install pip
+    #
+    pip install --upgrade pip && \
+    #
+    # We install some pip packages before adding the code in order to better leverage
+    # the docker cache
+    #
+    # Leave one library without install, so w3af_dependency_install is actually
+    # created and we can run the next commands without if statements
+    #
+    # tblib==0.2.0
+    #
+    pip install chardet==3.0.4 cluster==1.1.1b3 \
+                darts.util.lru==0.5 \
+                esmre==0.3.1 \
+                Flask==0.10.1 futures==2.1.5 \
+                GitPython==2.1.3 guess-language==0.2 \
+                halberd==0.2.4 \
+                Jinja2==2.7.3 \
+                lxml==3.4.4 \
+                markdown==2.6.1 mitmproxy==0.13 msgpack-python==0.4.4 ndg-httpsclient==0.3.3 \
+                nltk==3.0.1 \
+                PyGithub==1.21.0 PyYAML==3.12 pdfminer==20140328 pebble==4.3.2 phply==0.9.1 psutil==2.2.1 \
+                  pyClamd==0.4.0 pyOpenSSL==16.2.0 pyasn1==0.2.3 pybloomfiltermmap==0.3.14 python-ntlm==1.0.1 \
+                ruamel.ordereddict==0.4.8 \
+                scapy-real==2.2.0-dev \
+                termcolor==1.1.0 tldextract==1.7.2 \
+                vulndb==0.0.19
 
 #
-# We install some pip packages before adding the code in order to better leverage
-# the docker cache
-#
-# Leave one library without install, so w3af_dependency_install is actually
-# created and we can run the next commands without if statements
-#
-#tblib==0.2.0
-#
-RUN pip install clamd==1.0.1 PyGithub==1.21.0 GitPython==2.1.3 pybloomfiltermmap==0.3.14 \
-        esmre==0.3.1 phply==0.9.1 nltk==3.0.1 chardet==2.1.1 pdfminer==20140328 \
-        futures==2.1.5 pyOpenSSL==0.15.1 scapy-real==2.2.0-dev guess-language==0.2 cluster==1.1.1b3 \
-        msgpack-python==0.4.4 python-ntlm==1.0.1 halberd==0.2.4 darts.util.lru==0.5 \
-        ndg-httpsclient==0.3.3 pyasn1==0.1.7 Jinja2==2.7.3 \
-        vulndb==0.0.17 markdown==2.6.1 psutil==2.2.1 mitmproxy==0.12.1 \
-        ruamel.ordereddict==0.4.8 Flask==0.10.1 PyYAML==3.11
-
 # Install w3af
+#
 ADD . /home/w3af/w3af
 WORKDIR /home/w3af/w3af
-RUN ./w3af_console ; true
-
-# Change the install script to add the -y and not require input
-RUN sed 's/sudo //g' -i /tmp/w3af_dependency_install.sh
-RUN sed 's/apt-get/apt-get -y/g' -i /tmp/w3af_dependency_install.sh
-RUN sed 's/pip install/pip install --upgrade/g' -i /tmp/w3af_dependency_install.sh
-
-# Run the dependency installer
-RUN /tmp/w3af_dependency_install.sh
-
-# Run the dependency installer
-RUN ./w3af_gui ; true
-RUN sed 's/sudo //g' -i /tmp/w3af_dependency_install.sh
-RUN sed 's/apt-get/apt-get -y/g' -i /tmp/w3af_dependency_install.sh
-RUN sed 's/pip install/pip install --upgrade/g' -i /tmp/w3af_dependency_install.sh
-RUN /tmp/w3af_dependency_install.sh
-
-# Compile the py files into pyc in order to speed-up w3af's start
-RUN python -m compileall -q .
-
-# Cleanup to make the image smaller
-RUN rm /tmp/w3af_dependency_install.sh
-RUN apt-get clean
-RUN rm -rf /var/lib/apt/lists/*
-RUN rm -rf /tmp/pip-build-root
+RUN ./w3af_console ; true && \
+    #
+    # Change the install script to add the -y and not require input
+    #
+    sed 's/sudo //g' -i /tmp/w3af_dependency_install.sh && \
+    sed 's/apt-get/apt-get -y/g' -i /tmp/w3af_dependency_install.sh && \
+    sed 's/pip install/pip install --upgrade/g' -i /tmp/w3af_dependency_install.sh && \
+    #
+    # Run the dependency installer
+    #
+    /tmp/w3af_dependency_install.sh && \
+    #
+    # Run the dependency installer
+    #
+    ./w3af_gui ; true && \
+    sed 's/sudo //g' -i /tmp/w3af_dependency_install.sh && \
+    sed 's/apt-get/apt-get -y/g' -i /tmp/w3af_dependency_install.sh && \
+    sed 's/pip install/pip install --upgrade/g' -i /tmp/w3af_dependency_install.sh && \
+    /tmp/w3af_dependency_install.sh && \
+    #
+    # Compile the py files into pyc in order to speed-up w3af's start
+    #
+    python -m compileall -q . && \
+    #
+    # Cleanup to make the image smaller
+    #
+    rm /tmp/w3af_dependency_install.sh && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /tmp/pip-build-root
 
 EXPOSE 22 44444
 

--- a/extras/docker/simple-docker-build.sh
+++ b/extras/docker/simple-docker-build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -x
+set -e
+
+cp Dockerfile ../../
+cp .dockerignore ../../
+
+cd ../../
+
+if [ $# -eq 1 ]; then
+    TAG=$1
+else
+    echo "Image tag argument is required in the format REPOSITORY/IMAGE:TAG (andresriancho/w3af:stable)."
+    exit 1
+fi
+
+docker build -t ${TAG} .
+
+docker push ${TAG}
+
+rm -rf Dockerfile
+rm -rf .dockerignore
+
+cd extras/docker/

--- a/extras/docker/ubuntu:12.04/Dockerfile
+++ b/extras/docker/ubuntu:12.04/Dockerfile
@@ -1,0 +1,92 @@
+# w3af.org
+# https://github.com/andresriancho/w3af/tree/master/extras
+
+FROM ubuntu:12.04
+MAINTAINER Andres Riancho <andres.riancho@gmail.com>
+
+# Initial setup
+RUN mkdir /home/w3af
+WORKDIR /home/w3af
+ENV HOME /home/w3af
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LOGNAME w3af
+# Squash errors about "Falling back to ..." during package installation
+ENV TERM linux
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+# Update before installing any package
+RUN apt-get update -y
+RUN apt-get upgrade -y
+RUN apt-get dist-upgrade -y
+
+# Install basic and GUI requirements, python-lxml because it doesn't compile correctly from pip
+RUN apt-get install -y python-pip build-essential libxslt1-dev libxml2-dev libsqlite3-dev \
+                       libyaml-dev openssh-server python-dev git python-lxml wget libssl-dev \
+                       xdot python-gtk2 python-gtksourceview2 ubuntu-artwork dmz-cursor-theme \
+                       ca-certificates libffi-dev
+
+# Add the w3af user
+# TODO - actually use the w3af user instead of running everything as root
+RUN useradd w3af
+
+# Get ssh package ready
+RUN mkdir /var/run/sshd
+RUN echo 'root:w3af' | chpasswd
+RUN mkdir /home/w3af/.ssh/
+RUN echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDjXxcHjyVkwHT+dSYwS3vxhQxZAit6uZAFhuzA/dQ2vFu6jmPk1ewMGIYVO5D7xV3fo7/RXeCARzqHl6drw18gaxDoBG3ERI6LxVspIQYjDt5Vsqd1Lv++Jzyp/wkXDdAdioLTJyOerw7SOmznxqDj1QMPCQni4yhrE+pYH4XKxNx5SwxZTPgQWnQS7dasY23bv55OPgztI6KJzZidMEzzJVKBXHy1Ru/jjhmWBghiXYU5RBDLDYyT8gAoWedYgzVDmMZelLR6Y6ggNLOtMGiGYfPWDUz9Z6iDAUsOQBtCJy8Sj8RwSQNpmOgSzBanqnhed14hLwdYhnKWcPNMry71 w3af@w3af-docker.org' > /home/w3af/.ssh/w3af-docker.pub
+RUN mkdir -p /root/.ssh/
+RUN cat /home/w3af/.ssh/w3af-docker.pub >> /root/.ssh/authorized_keys
+
+# Get and install pip
+RUN pip install --upgrade pip
+
+#
+# We install some pip packages before adding the code in order to better leverage
+# the docker cache
+#
+# Leave one library without install, so w3af_dependency_install is actually
+# created and we can run the next commands without if statements
+#
+#tblib==0.2.0
+#
+RUN pip install clamd==1.0.1 PyGithub==1.21.0 GitPython==2.1.3 pybloomfiltermmap==0.3.14 \
+        esmre==0.3.1 phply==0.9.1 nltk==3.0.1 chardet==2.1.1 pdfminer==20140328 \
+        futures==2.1.5 pyOpenSSL==0.15.1 scapy-real==2.2.0-dev guess-language==0.2 cluster==1.1.1b3 \
+        msgpack-python==0.4.4 python-ntlm==1.0.1 halberd==0.2.4 darts.util.lru==0.5 \
+        ndg-httpsclient==0.3.3 pyasn1==0.1.7 Jinja2==2.7.3 \
+        vulndb==0.0.17 markdown==2.6.1 psutil==2.2.1 mitmproxy==0.12.1 \
+        ruamel.ordereddict==0.4.8 Flask==0.10.1 PyYAML==3.11
+
+# Install w3af
+ADD . /home/w3af/w3af
+WORKDIR /home/w3af/w3af
+RUN ./w3af_console ; true
+
+# Change the install script to add the -y and not require input
+RUN sed 's/sudo //g' -i /tmp/w3af_dependency_install.sh
+RUN sed 's/apt-get/apt-get -y/g' -i /tmp/w3af_dependency_install.sh
+RUN sed 's/pip install/pip install --upgrade/g' -i /tmp/w3af_dependency_install.sh
+
+# Run the dependency installer
+RUN /tmp/w3af_dependency_install.sh
+
+# Run the dependency installer
+RUN ./w3af_gui ; true
+RUN sed 's/sudo //g' -i /tmp/w3af_dependency_install.sh
+RUN sed 's/apt-get/apt-get -y/g' -i /tmp/w3af_dependency_install.sh
+RUN sed 's/pip install/pip install --upgrade/g' -i /tmp/w3af_dependency_install.sh
+RUN /tmp/w3af_dependency_install.sh
+
+# Compile the py files into pyc in order to speed-up w3af's start
+RUN python -m compileall -q .
+
+# Cleanup to make the image smaller
+RUN rm /tmp/w3af_dependency_install.sh
+RUN apt-get clean
+RUN rm -rf /var/lib/apt/lists/*
+RUN rm -rf /tmp/pip-build-root
+
+EXPOSE 22 44444
+
+CMD ["/usr/sbin/sshd", "-D"]

--- a/w3af/core/controllers/dependency_check/requirements.py
+++ b/w3af/core/controllers/dependency_check/requirements.py
@@ -25,7 +25,7 @@ CORE = 1
 GUI = 2
 
 
-CORE_PIP_PACKAGES = [PIPDependency('pyclamd', 'pyClamd', '0.3.15'),
+CORE_PIP_PACKAGES = [PIPDependency('pyclamd', 'pyClamd', '0.4.0'),
                      PIPDependency('github', 'PyGithub', '1.21.0'),
                      PIPDependency('git.util', 'GitPython', '2.1.3'),
                      PIPDependency('pybloomfilter', 'pybloomfiltermmap', '0.3.14'),
@@ -36,7 +36,7 @@ CORE_PIP_PACKAGES = [PIPDependency('pyclamd', 'pyClamd', '0.3.15'),
                      PIPDependency('tblib', 'tblib', '0.2.0'),
                      PIPDependency('pdfminer', 'pdfminer', '20140328'),
                      PIPDependency('concurrent.futures', 'futures', '2.1.5'),
-                     PIPDependency('OpenSSL', 'pyOpenSSL', '0.15.1'),
+                     PIPDependency('OpenSSL', 'pyOpenSSL', '16.2.0'),
                      PIPDependency('ndg', 'ndg-httpsclient', '0.3.3'),
 
                      # We need 0.1.8 because of mitmproxy


### PR DESCRIPTION
An updated Dockerfile is important so that anyone can build and run W3AF anywhere. Along with being able to build it, it is useful to be able to build this image with CI so that the most up to date version can be easily and automatically maintained.

This pull request contains:
* An updated Dockerfile.
  * More recent base image is being used.
  * Layers have been significantly compacted.
  * Pip dependencies have been fixed and update.
  * Updated deprecated directives.
* A Jenkinsfile.
  * This pipeline performs the build, push and cleaning steps that typically occurred in the provided build script.
  * Functional, was used to push this image: https://hub.docker.com/r/liatrio/w3af/
* 'simple-docker-build.sh'
  * Provides basic Docker build functionality.
* Miscellaneous file with references to Pip dependencies updated to match Dockerfile.
* Previous Dockerfile backed up in _/extras/docker/ubuntu:12.04_.