### PR TITLE
fix bug with detached terminal

### DIFF
--- a/w3af/core/ui/console/rootMenu.py
+++ b/w3af/core/ui/console/rootMenu.py
@@ -20,6 +20,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 """
 import sys
+import os
 import time
 import select
 
@@ -161,6 +162,12 @@ class rootMenu(menu):
         """
         When the user hits enter, show the progress
         """
+        # if run with detached terminal mode
+        if not os.isatty(sys.stdin.fileno()):
+            while self._w3af.status.is_running() or self._w3af.status.is_paused():
+                time.sleep(0.1)
+            return
+
         term.set_raw_input_mode(True)
 
         handlers = {'P': self._pause_scan,


### PR DESCRIPTION
When run w3af with detached terminal (by cron for example), a lot of errors was generated
the commit fix this problem

`./w3af_console -s ./scripts/sqli.w3af < /dev/null

Unknown key. The following commands are allowed during the scan:

(P) pause the scan
(R) resume a paused scan
(enter) print scan status
(Ctrl+C) stop scan

Unknown key. The following commands are allowed during the scan:

(P) pause the scan
(R) resume a paused scan
(enter) print scan status
(Ctrl+C) stop scan

Unknown key. The following commands are allowed during the scan:

(P) pause the scan
(R) resume a paused scan

`