### PR TITLE
fix type problem in clean_data_container

### DIFF
--- a/w3af/core/data/db/clean_dc.py
+++ b/w3af/core/data/db/clean_dc.py
@@ -42,7 +42,7 @@ def clean_data_container(data_container):
 
     for key, value, path, setter in data_container.iter_setters():
 
-        if value.isdigit():
+        if isinstance(value, int) or value.isdigit():
             _type = 'number'
         else:
             _type = 'string'


### PR DESCRIPTION
fix error - AttributeError: 'int' object has no attribute 'isdigit' when value is int
I will can fix it in most wide case like this, but i'm not sure:

        if isinstance(value, str):
            if value.isdigit():
                _type = 'number'
            else:
                _type = 'string'
        else:
            _type = type(value)