### PR TITLE
clean_data_container() should expect None value

### DIFF
--- a/w3af/core/data/db/clean_dc.py
+++ b/w3af/core/data/db/clean_dc.py
@@ -42,7 +42,9 @@ def clean_data_container(data_container):
 
     for key, value, path, setter in data_container.iter_setters():
 
-        if isinstance(value, (int, float)):
+        if value is None:
+            _type = 'none'
+        elif isinstance(value, (int, float)):
             _type = 'number'
         elif value.isdigit():
             _type = 'number'


### PR DESCRIPTION
I noticed that an NPE may occur in `clean_data_container()` function because `value` may be None:

`AttributeError: 'NoneType' object has no attribute 'isdigit'`

If I understand correctly, it's a valid case when `value` is None. For example, it may happen if a JSON payload contains a null. How about adding a check if `value` is None? I was also wondering if it should check that `key` is not null?