### PR TITLE
Don't use deepcopy() in ParameterHandler to make debugging great again

### DIFF
--- a/w3af/core/data/parsers/doc/open_api/parameters.py
+++ b/w3af/core/data/parsers/doc/open_api/parameters.py
@@ -20,9 +20,10 @@ along with w3af; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 """
-import copy
 import random
 import datetime
+
+from bravado_core.operation import Operation
 
 from w3af.core.data.fuzzer.form_filler import (smart_fill,
                                                smart_fill_file)
@@ -61,7 +62,11 @@ class ParameterHandler(object):
         """
         self._fix_common_spec_issues()
 
-        operation = copy.deepcopy(self.operation)
+        # Make a copy of the operation
+        operation = Operation.from_spec(self.operation.swagger_spec,
+                                        self.operation.path_name,
+                                        self.operation.http_method,
+                                        self.operation.op_spec)
 
         for parameter_name, parameter in operation.params.iteritems():
             # We make sure that all parameters have a fill attribute

--- a/w3af/core/data/parsers/doc/open_api/tests/test_specification.py
+++ b/w3af/core/data/parsers/doc/open_api/tests/test_specification.py
@@ -23,6 +23,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 import unittest
 import datetime
 
+from w3af.core.data.parsers.doc.open_api.parameters import ParameterHandler
 from w3af.core.data.parsers.doc.url import URL
 from w3af.core.data.dc.headers import Headers
 from w3af.core.data.url.HTTPResponse import HTTPResponse
@@ -41,11 +42,14 @@ from w3af.core.data.parsers.doc.open_api.tests.example_specifications import (No
                                                                               DereferencedPetStore,
                                                                               NestedModel,
                                                                               NestedLoopModel,
-                                                                              ArrayModelItems)
+                                                                              ArrayModelItems,
+                                                                              MultiplePathsAndHeaders)
 
 
 class TestSpecification(unittest.TestCase):
-    def generate_response(self, specification_as_string):
+
+    @staticmethod
+    def generate_response(specification_as_string):
         url = URL('http://www.w3af.com/swagger.json')
         headers = Headers([('content-type', 'application/json')])
         return HTTPResponse(200, specification_as_string, headers,
@@ -545,3 +549,69 @@ class TestSpecification(unittest.TestCase):
                                                   u'city': 'Buenos Aires'}},
                           u'type': 'cat', u'name': 'John', u'birthdate': datetime.date(2017, 6, 30)}
         self.assertEqual(param.fill, expected_value)
+
+    def test_parameter_handler_no_params(self):
+        specification_as_string = NoParams().get_specification()
+        http_response = self.generate_response(specification_as_string)
+        handler = SpecificationHandler(http_response)
+        self.check_parameter_setting(handler)
+
+    def test_parameter_handler_simple_int_param_in_qs(self):
+        specification_as_string = IntParamQueryString().get_specification()
+        http_response = self.generate_response(specification_as_string)
+        handler = SpecificationHandler(http_response)
+        self.check_parameter_setting(handler)
+
+    def test_parameter_handler_array_string_items_param_in_qs(self):
+        specification_as_string = ArrayStringItemsQueryString().get_specification()
+        http_response = self.generate_response(specification_as_string)
+        handler = SpecificationHandler(http_response)
+        self.check_parameter_setting(handler)
+
+    def test_parameter_handler_no_model_json_object_complex_nested_in_body(self):
+        specification_as_string = ComplexDereferencedNestedModel().get_specification()
+        http_response = self.generate_response(specification_as_string)
+        handler = SpecificationHandler(http_response)
+        self.check_parameter_setting(handler)
+
+    def test_parameter_handler_model_param_nested_allOf_in_json(self):
+        specification_as_string = NestedModel().get_specification()
+        http_response = self.generate_response(specification_as_string)
+        handler = SpecificationHandler(http_response)
+        self.check_parameter_setting(handler)
+
+    def test_parameter_handler_multiple_paths_and_headers(self):
+        specification_as_string = MultiplePathsAndHeaders().get_specification()
+        http_response = self.generate_response(specification_as_string)
+        handler = SpecificationHandler(http_response)
+        self.check_parameter_setting(handler)
+
+    def check_parameter_setting(self, spec_handler):
+        data = [d for d in spec_handler.get_api_information()]
+        self.assertIsNotNone(data)
+        self.assertIsNotNone(spec_handler.spec)
+
+        for api_resource_name, resource in spec_handler.spec.resources.items():
+            for operation_name, operation in resource.operations.items():
+
+                # Make sure that the parameter doesn't have a value yet
+                for parameter_name, parameter in operation.params.iteritems():
+                    self.assertFalse(hasattr(parameter, 'fill'))
+
+                parameter_handler = ParameterHandler(spec_handler.spec, operation)
+                updated_operation = parameter_handler.set_operation_params(True)
+                self.assertOperation(operation, updated_operation)
+
+                parameter_handler = ParameterHandler(spec_handler.spec, operation)
+                updated_operation = parameter_handler.set_operation_params(False)
+                self.assertOperation(operation, updated_operation)
+
+    def assertOperation(self, operation, updated_operation):
+
+        # Make sure that the parameter now has a value
+        for parameter_name, parameter in updated_operation.params.iteritems():
+            self.assertTrue(hasattr(parameter, 'fill'))
+
+        # Make sure that the original operation doesn't get updated
+        # after set_operation_params() call
+        self.assertNotEquals(operation, updated_operation)


### PR DESCRIPTION
While running a scan against a RESTful application, I noticed that debugging doesn't work well sometimes. In particular, the debugger couldn't stop on a breakpoint under some circumstances. Then, I found the following error messages in logs which seem to cause the problem:

> Exception RuntimeError: 'maximum recursion depth exceeded in __subclasscheck__' in <type 'exceptions.RuntimeError'> ignored
Exception RuntimeError: 'maximum recursion depth exceeded in __subclasscheck__' in <type 'exceptions.RuntimeError'> ignored

It turned out that the errors above are caused by calling `deepcopy()` on Bravado's objects in `ParameterHandler`. It looks similar to https://stackoverflow.com/questions/32831050/pycharms-debugger-gives-up-when-hitting-copy-deepcopy

Updating bravado-core to 5.0.7 didn't help.

In this patch, I'd like to propose getting rid of `deepcopy` in `ParameterHandler`. It tried to replace it with `Operation.from_spec()`. It seems to work well, and fixes the problem with debugging.

https://github.com/Yelp/bravado-core/blob/master/bravado_core/operation.py#L121

