### PR TITLE
Prefer content types from 'consumes' list in Open API spec

### DIFF
--- a/w3af/core/data/dc/generic/data_container.py
+++ b/w3af/core/data/dc/generic/data_container.py
@@ -227,6 +227,16 @@ class DataContainer(DiskItem):
         """
         return []
 
+    def set_header(self, header, value):
+        """
+        Sets a header required to send the self._post_data to the wire.
+        Override in sub-classes with care.
+
+        :param header: Header name
+        :param value:  Header value
+        """
+        pass
+
     @property
     def all_items(self):
         return str(self)

--- a/w3af/core/data/dc/tests/test_json_container.py
+++ b/w3af/core/data/dc/tests/test_json_container.py
@@ -148,6 +148,16 @@ class TestJSONContainer(unittest.TestCase):
         e_headers = [('Content-Type', 'application/json')]
         self.assertEquals(jcont.get_headers(), e_headers)
 
+    def test_headers_immutable(self):
+        jcont = JSONContainer(OBJECT)
+
+        e_headers = [('Content-Type', 'application/json')]
+        headers = jcont.get_headers()
+        self.assertEquals(headers, e_headers)
+
+        headers.append(('X-Foo-Header', 'Bar'))
+        self.assertEquals(jcont.get_headers(), e_headers)
+
     def test_wrong_headers(self):
         jcont = JSONContainer(COMPLEX_OBJECT)
 

--- a/w3af/core/data/dc/tests/test_json_container.py
+++ b/w3af/core/data/dc/tests/test_json_container.py
@@ -119,3 +119,46 @@ class TestJSONContainer(unittest.TestCase):
 
         dc_copy = copy.deepcopy(dc)
         self.assertIsNotNone(dc_copy.get_token())
+
+    def test_headers(self):
+        jcont = JSONContainer(COMPLEX_OBJECT)
+
+        e_headers = [('Content-Type', 'application/json')]
+        self.assertEquals(jcont.get_headers(), e_headers)
+
+        jcont.set_header('Content-Type', 'application/vnd.w3af+json')
+        e_headers = [('Content-Type', 'application/vnd.w3af+json')]
+        self.assertEquals(jcont.get_headers(), e_headers)
+
+        jcont.set_header('X-Foo-Header', 'Bar')
+        e_headers = [('Content-Type', 'application/vnd.w3af+json'), ('X-Foo-Header', 'Bar')]
+        self.assertEquals(jcont.get_headers(), e_headers)
+
+        headers = {'Content-Type': 'application/vnd.w3af+json', 'X-Foo-Header': 'Bar'}
+        jcont = JSONContainer(COMPLEX_OBJECT, headers)
+
+        e_headers = [('Content-Type', 'application/vnd.w3af+json'), ('X-Foo-Header', 'Bar')]
+        self.assertEquals(jcont.get_headers(), e_headers)
+
+        jcont.set_header('X-Foo-Header', '42')
+        e_headers = [('Content-Type', 'application/vnd.w3af+json'), ('X-Foo-Header', '42')]
+        self.assertEquals(jcont.get_headers(), e_headers)
+
+        jcont = JSONContainer(COMPLEX_OBJECT, None)
+        e_headers = [('Content-Type', 'application/json')]
+        self.assertEquals(jcont.get_headers(), e_headers)
+
+    def test_wrong_headers(self):
+        jcont = JSONContainer(COMPLEX_OBJECT)
+
+        with self.assertRaises(TypeError):
+            jcont.set_header(1, 'Foo')
+
+        with self.assertRaises(TypeError):
+            jcont.set_header('Foo', 1)
+
+        with self.assertRaises(TypeError):
+            JSONContainer(COMPLEX_OBJECT, 'Foo')
+
+        with self.assertRaises(TypeError):
+            JSONContainer(COMPLEX_OBJECT, [])

--- a/w3af/core/data/dc/tests/test_json_container.py
+++ b/w3af/core/data/dc/tests/test_json_container.py
@@ -19,6 +19,7 @@ You should have received a copy of the GNU General Public License
 along with w3af; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 """
+import pickle
 import unittest
 import copy
 
@@ -172,3 +173,33 @@ class TestJSONContainer(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             JSONContainer(COMPLEX_OBJECT, [])
+
+    def test_pickle(self):
+        original = JSONContainer(COMPLEX_OBJECT)
+
+        e_headers = [('Content-Type', 'application/json')]
+        self.assertEquals(original.get_headers(), e_headers)
+
+        clone = pickle.loads(pickle.dumps(original))
+        self.assertEquals(original, clone)
+        self.assertEquals(clone.get_headers(), e_headers)
+
+        original = JSONContainer(COMPLEX_OBJECT)
+        original.set_header('Content-Type', 'application/vnd.w3af+json')
+
+        e_headers = [('Content-Type', 'application/vnd.w3af+json')]
+        self.assertEquals(original.get_headers(), e_headers)
+
+        clone = pickle.loads(pickle.dumps(original))
+        self.assertEquals(original, clone)
+        self.assertEquals(clone.get_headers(), e_headers)
+
+        original = JSONContainer(COMPLEX_OBJECT)
+        original.set_header('X-Foo-Header', 'Bar')
+
+        e_headers = [('Content-Type', 'application/json'), ('X-Foo-Header', 'Bar')]
+        self.assertEquals(original.get_headers(), e_headers)
+
+        clone = pickle.loads(pickle.dumps(original))
+        self.assertEquals(original, clone)
+        self.assertEquals(clone.get_headers(), e_headers)

--- a/w3af/core/data/parsers/doc/open_api/requests.py
+++ b/w3af/core/data/parsers/doc/open_api/requests.py
@@ -25,7 +25,6 @@ from w3af.core.data.dc.query_string import QueryString
 from w3af.core.data.dc.json_container import JSONContainer
 from w3af.core.data.dc.factory import dc_from_content_type_and_raw_params
 from w3af.core.data.dc.urlencoded_form import URLEncodedForm
-from w3af.core.data.dc.xmlrpc import XmlRpcContainer
 from w3af.core.data.dc.multipart_container import MultipartContainer
 from w3af.core.data.request.fuzzable_request import FuzzableRequest
 from w3af.core.data.parsers.doc.url import URL

--- a/w3af/core/data/parsers/doc/open_api/requests.py
+++ b/w3af/core/data/parsers/doc/open_api/requests.py
@@ -24,6 +24,9 @@ from w3af.core.data.dc.headers import Headers
 from w3af.core.data.dc.query_string import QueryString
 from w3af.core.data.dc.json_container import JSONContainer
 from w3af.core.data.dc.factory import dc_from_content_type_and_raw_params
+from w3af.core.data.dc.urlencoded_form import URLEncodedForm
+from w3af.core.data.dc.xmlrpc import XmlRpcContainer
+from w3af.core.data.dc.multipart_container import MultipartContainer
 from w3af.core.data.request.fuzzable_request import FuzzableRequest
 from w3af.core.data.parsers.doc.url import URL
 from w3af.core.data.parsers.doc.open_api.construct_request import construct_request
@@ -177,15 +180,11 @@ class RequestFactory(object):
         request_dict = self._bravado_construct_request()
         headers = Headers(request_dict['headers'].items())
 
-        # First, we try to extract content type from the operation.
-        #
-        # The REST API endpoint might support more than one content-type
-        # for consuming it. We only use the first one since in 99% of the cases
-        # a vulnerability which we find using one content-type will be present
-        # in others. This works the other way around also, there are very few
-        # vulnerabilities which are going to be exploitable with one content-type.
-        if self.operation.consumes:
-            headers['Content-Type'] = self.operation.consumes[0]
+        # First, we try to extract content type from a 'consumes'
+        # if the operation has one.
+        content_type = self.get_consuming_content_type()
+        if content_type is not None:
+            headers['Content-Type'] = content_type
 
         content_type, _ = headers.iget('content-type', None)
         if content_type is None and self.parameters:
@@ -200,6 +199,43 @@ class RequestFactory(object):
             headers['Content-Type'] = self.DEFAULT_CONTENT_TYPE
 
         return headers
+
+    def get_consuming_content_type(self):
+        """
+        Look for the best content type in a 'consumes' list of the operation.
+
+        First, check if any of the consumes values contains JSON,
+        and choose that one. If that fails, continue with url-encoded,
+        and finally multipart.
+
+        The method throws an exception if no data container was found
+        for content types specified in the 'consumes' list.
+
+        :return: One of the content types listed in the 'consumes' list,
+                 or None if the operation doesn't have a 'consumes' list.
+        """
+        if not self.operation.consumes:
+            return None
+
+        container_types = [JSONContainer, MultipartContainer,
+                           URLEncodedForm, XmlRpcContainer]
+        for container_type in container_types:
+            content_type = self._look_for_consuming_content_type(container_type)
+            if content_type is not None:
+                return content_type
+
+        raise ValueError("'consumes' list contains only unknown content types")
+
+    def _look_for_consuming_content_type(self, container_type):
+        if not self.operation.consumes:
+            return None
+
+        for content_type in self.operation.consumes:
+            temp_headers = Headers([('Content-Type', content_type)])
+            if container_type.content_type_matches(temp_headers):
+                return content_type
+
+        return None
 
     def get_data_container(self, headers):
         """
@@ -228,6 +264,10 @@ class RequestFactory(object):
 
         # Create the data container
         dc = dc_from_content_type_and_raw_params(content_type, parameters)
+        if dc is None:
+            om.out.error("No data container for content type '%s'" % content_type)
+            return None
+
         dc.set_header('Content-Type', content_type)
 
         return dc

--- a/w3af/core/data/parsers/doc/open_api/requests.py
+++ b/w3af/core/data/parsers/doc/open_api/requests.py
@@ -217,8 +217,7 @@ class RequestFactory(object):
         if not self.operation.consumes:
             return None
 
-        container_types = [JSONContainer, MultipartContainer,
-                           URLEncodedForm, XmlRpcContainer]
+        container_types = [JSONContainer, MultipartContainer, URLEncodedForm]
         for container_type in container_types:
             content_type = self._look_for_consuming_content_type(container_type)
             if content_type is not None:

--- a/w3af/core/data/parsers/doc/open_api/tests/data/custom_content_type.json
+++ b/w3af/core/data/parsers/doc/open_api/tests/data/custom_content_type.json
@@ -1,0 +1,113 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "Swagger API Team"
+    },
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "w3af.org",
+  "basePath": "/api",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "post": {
+        "description": "Updates a pet",
+        "operationId": "updatePet",
+        "consumes": [
+          "application/vnd.w3af+json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "info",
+            "in": "body",
+            "description": "Information about the pet",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "tag": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          {
+            "name": "X-Foo-Header",
+            "in": "header",
+            "description": "Just a magic header",
+            "required": true,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/NewPet"
+        },
+        {
+          "required": [
+            "id"
+          ],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        }
+      ]
+    },
+    "NewPet": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/w3af/core/data/parsers/doc/open_api/tests/data/unknown_content_type.json
+++ b/w3af/core/data/parsers/doc/open_api/tests/data/unknown_content_type.json
@@ -29,7 +29,7 @@
         "description": "Updates a pet",
         "operationId": "updatePet",
         "consumes": [
-          "application/vnd.w3af+json"
+          "application/vnd.w3af"
         ],
         "produces": [
           "application/json"
@@ -50,47 +50,6 @@
                   "type": "string"
                 }
               }
-            }
-          },
-          {
-            "name": "X-Foo-Header",
-            "in": "header",
-            "description": "Just a magic header",
-            "required": true,
-            "type": "integer",
-            "format": "int32"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "pet response",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Pet"
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "description": "Creates a pet",
-        "operationId": "createPet",
-        "consumes": [
-          "application/x-www-form-urlencoded",
-          "application/vnd.w3af+json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "info",
-            "in": "body",
-            "description": "Information about the pet",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/Pet"
             }
           }
         ],

--- a/w3af/core/data/parsers/doc/open_api/tests/test_main.py
+++ b/w3af/core/data/parsers/doc/open_api/tests/test_main.py
@@ -45,6 +45,7 @@ class TestOpenAPIMain(unittest.TestCase):
     MULTIPLE_PATHS_AND_HEADERS = os.path.join(DATA_PATH, 'multiple_paths_and_headers.json')
     NOT_VALID_SPEC = os.path.join(DATA_PATH, 'not_quite_valid_petstore_simple.json')
     CUSTOM_CONTENT_TYPE = os.path.join(DATA_PATH, 'custom_content_type.json')
+    UNKNOWN_CONTENT_TYPE = os.path.join(DATA_PATH, 'unknown_content_type.json')
 
     def test_json_pet_store(self):
         # http://petstore.swagger.io/v2/swagger.json
@@ -203,6 +204,7 @@ class TestOpenAPIMain(unittest.TestCase):
         self.assertEquals(api_call.get_headers(), e_headers)
         self.assertEqual(api_call.get_force_fuzzing_headers(), e_force_fuzzing_headers)
 
+    # Check if the OpenAPI plugin takes into account content types provided in a 'consumes' list.
     def test_custom_content_type(self):
         body = file(self.CUSTOM_CONTENT_TYPE).read()
         headers = Headers({'Content-Type': 'application/json'}.items())
@@ -217,12 +219,32 @@ class TestOpenAPIMain(unittest.TestCase):
 
         api_calls.sort(by_path)
 
-        self.assertEqual(len(api_calls), 1)
+        self.assertEqual(len(api_calls), 2)
 
         #
         # Assertions on call #1
         #
         api_call = api_calls[0]
+
+        e_url = 'http://w3af.org/api/pets'
+        e_force_fuzzing_headers = []
+        e_headers = Headers([('Content-Type', 'application/vnd.w3af+json')])
+        e_post_data_headers = Headers([('Content-Type', 'application/vnd.w3af+json')])
+        e_all_headers = Headers([('Content-Type', 'application/vnd.w3af+json')])
+
+        self.assertIsInstance(api_call.get_raw_data(), JSONContainer)
+        self.assertEquals(api_call.get_method(), 'PUT')
+        self.assertEquals(api_call.get_uri().url_string, e_url)
+        self.assertEquals(api_call.get_headers(), e_headers)
+        self.assertEquals(api_call.get_post_data_headers(), e_post_data_headers)
+        self.assertEquals(api_call.get_all_headers(), e_all_headers)
+        self.assertEquals(api_call.get_force_fuzzing_headers(), e_force_fuzzing_headers)
+        self.assertEquals(str(api_call.get_raw_data()), '{"info": {"tag": "7", "name": "John", "id": 42}}')
+
+        #
+        # Assertions on call #2
+        #
+        api_call = api_calls[1]
 
         e_url = 'http://w3af.org/api/pets'
         e_force_fuzzing_headers = ['X-Foo-Header']
@@ -238,6 +260,21 @@ class TestOpenAPIMain(unittest.TestCase):
         self.assertEquals(api_call.get_all_headers(), e_all_headers)
         self.assertEquals(api_call.get_force_fuzzing_headers(), e_force_fuzzing_headers)
         self.assertEquals(str(api_call.get_raw_data()), '{"info": {"tag": "7", "name": "John"}}')
+
+    # Check if the OpenAPI plugin doesn't return a fuzzable request for a endpoint
+    # which contains an unknown content type in its 'consumes' list.
+    def test_unknown_content_type(self):
+        body = file(self.UNKNOWN_CONTENT_TYPE).read()
+        headers = Headers({'Content-Type': 'application/json'}.items())
+        response = HTTPResponse(200, body, headers,
+                                URL('http://moth/swagger.json'),
+                                URL('http://moth/swagger.json'),
+                                _id=1)
+
+        parser = OpenAPI(response)
+        parser.parse()
+        api_calls = parser.get_api_calls()
+        self.assertEquals(api_calls, [])
 
     def test_disabling_headers_discovery(self):
         body = file(self.MULTIPLE_PATHS_AND_HEADERS).read()


### PR DESCRIPTION
Open API specification defines  `consumes` parameter for a endpoint which allows to specify content types which the endpoint can consume. Many RESTful applications use standard content types such as `application/json`, but some of them define custom types like `application/vnd.awesome.application+json`. Such endpoints may respond with 415 error code (Unsupported Media Type) to requests which don't specify an expected custom content type in `Content-Type` header.

The Open API plugin is aware of `consumes` parameter but it usually prefers to use the standard `application/json` type for JSON payloads. As a result, it may be hard to test a endpoint which requires a custom content type. In fact, I couldn't configure w3af to use content types defined in `consumes`. As a workaround, we can try to set `Content-Type` header in `http-settings -> headers_file`. But if a RESTful application provides multiple endpoints which use different custom content types, then we can efficiently scan all of them in one scan.

In this patch, I'd like to propose updating w3af to prefer content types from `consumes` list.

Changes:

- Updated `RequestFactory` to prefer content types from `consumes` list
- Added `set_header()` method to `JSONContainer` to support setting headers (I noticed that headers from a data container may override the headers which were set to a fuzzable request before, see `FuzzableRequest.get_all_headers()` method)
- Updated `DataContainer` with default implementation of `set_header()` method
- Added several tests