### PR TITLE
Update scapy depedency

### DIFF
--- a/w3af/core/controllers/dependency_check/platforms/mac.py
+++ b/w3af/core/controllers/dependency_check/platforms/mac.py
@@ -43,17 +43,6 @@ ports Python by using the following command:
 TRACEROUTE_SCAPY_MSG = """\
 Tried to import traceroute from scapy.all and found an OSError including the
 message "Device not configured".
-
-This is a bug in the scapy library and happens on OSX with MacPorts i.e. when
-Virtualbox is installed.
-
-Please apply the following fix (example for python 2.7):
-    - Open the file /opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/scapy/arch/unix.py
-    - Change line 34 to read:
-        f=os.popen("netstat -rn|grep -v vboxnet") # -f inet
-
-Original bug report:
-    http://bb.secdev.org/scapy/issue/418/scapy-error-in-mac-osx-leopard
 """
 
 

--- a/w3af/core/controllers/dependency_check/requirements.py
+++ b/w3af/core/controllers/dependency_check/requirements.py
@@ -42,7 +42,7 @@ CORE_PIP_PACKAGES = [PIPDependency('pyclamd', 'pyClamd', '0.4.0'),
                      PIPDependency('pyasn1', 'pyasn1', '0.4.2'),
 
                      PIPDependency('lxml', 'lxml', '3.4.4'),
-                     PIPDependency('scapy.config', 'scapy-real', '2.2.0-dev'),
+                     PIPDependency('scapy.config', 'scapy', '2.4.0'),
                      PIPDependency('guess_language', 'guess-language', '0.2'),
                      PIPDependency('cluster', 'cluster', '1.1.1b3'),
                      PIPDependency('msgpack', 'msgpack', '0.5.6'),


### PR DESCRIPTION
Hello !

Scapy-real is a super outdated project, that was only updated once in 2013
The real version is `scapy`, and it now contains all features that were temporarily held in scapy-real.

We are planning to break the scapy-real package on PyPi to avoid confusion