### PR TITLE
Don't force fuzzing auth headers for API endpoints

### DIFF
--- a/w3af/core/data/parsers/doc/open_api/tests/example_specifications.py
+++ b/w3af/core/data/parsers/doc/open_api/tests/example_specifications.py
@@ -79,6 +79,13 @@ class MultiplePathsAndHeaders(object):
         return file('%s/data/multiple_paths_and_headers.json' % CURRENT_PATH).read()
 
 
+class PetstoreModel(object):
+
+    @staticmethod
+    def get_specification():
+        return file('%s/data/swagger.json' % CURRENT_PATH).read()
+
+
 class IntParamPath(object):
     def get_specification(self):
         spec = APISpec(

--- a/w3af/core/data/parsers/doc/open_api/tests/test_requests.py
+++ b/w3af/core/data/parsers/doc/open_api/tests/test_requests.py
@@ -37,11 +37,13 @@ from w3af.core.data.parsers.doc.open_api.tests.example_specifications import (No
                                                                               ComplexDereferencedNestedModel,
                                                                               DereferencedPetStore,
                                                                               NestedModel,
-                                                                              ArrayModelItems)
+                                                                              ArrayModelItems, PetstoreModel)
 
 
 class TestRequests(unittest.TestCase):
-    def generate_response(self, specification_as_string):
+
+    @staticmethod
+    def generate_response(specification_as_string):
         url = URL('http://www.w3af.com/swagger.json')
         headers = Headers([('content-type', 'application/json')])
         return HTTPResponse(200, specification_as_string, headers,
@@ -380,3 +382,18 @@ class TestRequests(unittest.TestCase):
         self.assertEqual(fuzzable_request.get_uri().url_string, e_url)
         self.assertEqual(fuzzable_request.get_headers(), e_headers)
         self.assertEqual(fuzzable_request.get_data(), e_data)
+
+    def test_no_forcing_fuzzing_auth_headers(self):
+        specification_as_string = PetstoreModel().get_specification()
+        http_response = self.generate_response(specification_as_string)
+        handler = SpecificationHandler(http_response)
+
+        data = [d for d in handler.get_api_information()]
+
+        self.assertTrue(len(data) > 0)
+        for data_i in data:
+            factory = RequestFactory(*data_i)
+            fuzzable_request = factory.get_fuzzable_request(discover_fuzzable_headers=True)
+            fuzzing_headers = fuzzable_request.get_force_fuzzing_headers()
+            self.assertNotIn('api_key', fuzzing_headers)
+            self.assertNotIn('Authorization', fuzzing_headers)


### PR DESCRIPTION
I noticed that the OpenAPI plugin forces fuzzing for auth headers. For example, it can happen if the API spec defines authentication with API keys passed in a header. Usually, a user provides such an auth header which then should be included to all HTTP request without any modification. So, it doesn't make much sense to force fuzzing for this header.

This patch fixes this issue. It updates `RequestFactory` to filter out auth headers.