### PR TITLE
Update OpenAPI plugin to fuzz URL parts by default

### DIFF
--- a/w3af/core/data/parsers/doc/open_api/tests/data/petstore-simple.json
+++ b/w3af/core/data/parsers/doc/open_api/tests/data/petstore-simple.json
@@ -12,7 +12,7 @@
       "name": "MIT"
     }
   },
-  "host": "petstore.swagger.io",
+  "host": "w3af.org",
   "basePath": "/api",
   "schemes": [
     "http"

--- a/w3af/core/data/parsers/doc/open_api/tests/data/petstore-simple.json
+++ b/w3af/core/data/parsers/doc/open_api/tests/data/petstore-simple.json
@@ -12,7 +12,7 @@
       "name": "MIT"
     }
   },
-  "host": "w3af.org",
+  "host": "petstore.swagger.io",
   "basePath": "/api",
   "schemes": [
     "http"

--- a/w3af/core/data/parsers/doc/open_api/tests/example_specifications.py
+++ b/w3af/core/data/parsers/doc/open_api/tests/example_specifications.py
@@ -79,6 +79,13 @@ class MultiplePathsAndHeaders(object):
         return file('%s/data/multiple_paths_and_headers.json' % CURRENT_PATH).read()
 
 
+class PetstoreSimpleModel(object):
+
+    @staticmethod
+    def get_specification():
+        return file('%s/data/petstore-simple.json' % CURRENT_PATH).read()
+
+
 class IntParamPath(object):
     def get_specification(self):
         spec = APISpec(

--- a/w3af/plugins/crawl/open_api.py
+++ b/w3af/plugins/crawl/open_api.py
@@ -85,10 +85,10 @@ class open_api(CrawlPlugin):
         :param fuzzable_request: A fuzzable_request instance that contains
                                 (among other things) the URL to test.
         """
+        self._enable_file_name_fuzzing()
         if self._has_custom_spec_location():
             self._analyze_custom_spec()
         else:
-            self._enable_file_name_fuzzing()
             self._analyze_common_paths(fuzzable_request)
             self._analyze_current_path(fuzzable_request)
 
@@ -106,6 +106,7 @@ class open_api(CrawlPlugin):
         """
         if self._first_run:
             cf.cf.save('fuzz_url_filenames', True)
+            cf.cf.save('fuzz_url_parts', True)
 
     def _should_analyze(self, url):
         """
@@ -169,7 +170,9 @@ class open_api(CrawlPlugin):
         if not OpenAPI.can_parse(http_response):
             return
 
-        parser = OpenAPI(http_response, self._no_spec_validation, self._discover_fuzzable_headers)
+        parser = OpenAPI(http_response,
+                         self._no_spec_validation,
+                         self._discover_fuzzable_headers)
         parser.parse()
 
         self._report_to_kb_if_needed(http_response, parser)
@@ -186,7 +189,8 @@ class open_api(CrawlPlugin):
         fuzzable_request = FuzzableRequest(spec_url, method='GET')
         self.output_queue.put(fuzzable_request)
 
-    def _is_target_domain(self, fuzzable_request):
+    @staticmethod
+    def _is_target_domain(fuzzable_request):
         """
         :param fuzzable_request: The api call as a fuzzable request
         :return: True if the target domain matches

--- a/w3af/plugins/tests/crawl/test_open_api.py
+++ b/w3af/plugins/tests/crawl/test_open_api.py
@@ -132,8 +132,6 @@ class TestOpenAPINestedModelSpec(PluginTest):
             if basic != TestOpenAPINestedModelSpec.BEARER:
                 return 401, response_headers, ''
 
-            print('debug: get_response: uri = %s' % uri)
-
             # The body is in json format, need to escape my double quotes
             request_body = json.dumps(http_request.parsed_body)
             payloads = [p.replace('"', '\\"') for p in sqli.SQLI_STRINGS]
@@ -294,11 +292,10 @@ class TestOpenAPIFindsSpecInOtherDirectory2(PluginTest):
 
 
 class TestOpenAPIFuzzURLParts(PluginTest):
+
     api_key = 'xxx'
-
-    target_url = 'http://w3af.org/'
-
-    vulnerable_url = 'http://w3af.org/api/pets/1%25272%25223'
+    target_url = 'http://petstore.swagger.io/'
+    vulnerable_url = 'http://petstore.swagger.io/api/pets/1%25272%25223'
 
     _run_configs = {
         'cfg': {
@@ -323,27 +320,26 @@ class TestOpenAPIFuzzURLParts(PluginTest):
 
             response_body = 'Sunny outside'
             if uri == TestOpenAPIFuzzURLParts.vulnerable_url:
-                print('debug: get_response: uri = %s' % uri)
                 response_body = 'PostgreSQL query failed:'
 
             return self.status, response_headers, response_body
 
-    MOCK_RESPONSES = [MockResponse('http://w3af.org/openapi.json',
+    MOCK_RESPONSES = [MockResponse('http://petstore.swagger.io/openapi.json',
                                    PetstoreSimpleModel().get_specification(),
                                    content_type='application/json'),
 
-                      SQLIMockResponse(re.compile('http://w3af.org/api/.*'),
-                                       body=None,
+                      SQLIMockResponse(re.compile('http://petstore.swagger.io/api/pets.*'),
+                                       body='{}',
                                        method='GET',
                                        status=200),
 
-                      SQLIMockResponse(re.compile('http://w3af.org/api/.*'),
-                                       body=None,
+                      SQLIMockResponse(re.compile('http://petstore.swagger.io/api/pets.*'),
+                                       body='{}',
                                        method='POST',
                                        status=200)
                       ]
 
-    def test_mp(self):
+    def test_fuzzing_parameters_in_path(self):
         cfg = self._run_configs['cfg']
         self._scan(cfg['target'], cfg['plugins'])
 


### PR DESCRIPTION
This is a patch for #17342

Changes:

- Updated the OpenAPI plugin to always turn on `fuzz_url_filenames` and `fuzz_url_parts` options.
- A couple of minor/cosmetic enhancements in `open_api.py`.
- Fixed `TestOpenAPIFindAllEndpointsWithAuth`.
- Added `TestOpenAPIFuzzURLParts`.