### PR TITLE
Add audit.open_api_auth plugin

### DIFF
--- a/w3af/core/data/parsers/doc/open_api/main.py
+++ b/w3af/core/data/parsers/doc/open_api/main.py
@@ -45,6 +45,11 @@ class OpenAPI(BaseParser):
     The parser only returns interesting results for get_forms(), where all
     FuzzableRequests associated with REST API calls are returned.
 
+    The parser stores a couple of things to the kb which then can be used by other plugins:
+      * An instance of SpecificationHandler which provides the API specification.
+      * A mapping { method, url -> operation id } which allows to find the operation
+        which is associated with a fuzzable request.
+
     [0] https://www.openapis.org/
     [1] https://github.com/Yelp/bravado-core
 
@@ -140,15 +145,13 @@ class OpenAPI(BaseParser):
 
     def get_specification_handler(self):
         """
-        TODO
-        :return:
+        :return: An instance of SpecificationHandler which was used by the parser.
         """
         return self.specification_handler
 
     def get_request_to_operation_id(self):
         """
-        TODO
-        :return:
+        :return: A mapping { method, url -> operation id }
         """
         return self.request_to_operation_id
 

--- a/w3af/core/data/parsers/doc/open_api/main.py
+++ b/w3af/core/data/parsers/doc/open_api/main.py
@@ -67,6 +67,7 @@ class OpenAPI(BaseParser):
         self.api_calls = []
         self.no_validation = no_validation
         self.discover_fuzzable_headers = discover_fuzzable_headers
+        self.specification_handler = None
 
     @staticmethod
     def content_type_match(http_resp):
@@ -136,6 +137,13 @@ class OpenAPI(BaseParser):
         # sure until we really parse it in OpenAPI.parse()
         return True
 
+    def get_specification_handler(self):
+        """
+        TODO
+        :return:
+        """
+        return self.specification_handler
+
     def parse(self):
         """
         Extract all the API endpoints using the bravado Open API parser.
@@ -143,10 +151,10 @@ class OpenAPI(BaseParser):
         The method also looks for all parameters which are passed to endpoints via headers,
         and stores them in to the fuzzable request
         """
-        specification_handler = SpecificationHandler(self.get_http_response(),
-                                                     self.no_validation)
+        self.specification_handler = SpecificationHandler(self.get_http_response(),
+                                                          self.no_validation)
 
-        for data in specification_handler.get_api_information():
+        for data in self.specification_handler.get_api_information():
             try:
                 request_factory = RequestFactory(*data)
                 fuzzable_request = request_factory.get_fuzzable_request(self.discover_fuzzable_headers)

--- a/w3af/core/data/parsers/doc/open_api/specification.py
+++ b/w3af/core/data/parsers/doc/open_api/specification.py
@@ -58,6 +58,26 @@ class SpecificationHandler(object):
     def get_http_response(self):
         return self.http_response
 
+    def shallow_copy(self):
+        """
+        TODO
+        :return:
+        """
+        return SpecificationHandler(self.http_response, self.no_validation)
+
+    def parse(self):
+        """
+        TODO
+        :return:
+        """
+        spec_dict = self._load_spec_dict()
+        if spec_dict is None:
+            return None
+
+        self.spec = self._parse_spec_from_dict(spec_dict)
+
+        return self.spec
+
     def get_api_information(self):
         """
         This is the main method.
@@ -65,13 +85,10 @@ class SpecificationHandler(object):
         :yield: All the information we were able to collect about each API endpoint
                 This includes the specification, parameters, URL, etc.
         """
-        spec_dict = self._load_spec_dict()
+        if not self.spec:
+            self.parse()
 
-        if spec_dict is None:
-            return
-
-        self.spec = self._parse_spec_from_dict(spec_dict)
-        if self.spec is None:
+        if not self.spec:
             return
 
         for api_resource_name, resource in self.spec.resources.items():

--- a/w3af/core/data/parsers/doc/open_api/specification.py
+++ b/w3af/core/data/parsers/doc/open_api/specification.py
@@ -65,6 +65,13 @@ class SpecificationHandler(object):
         """
         return SpecificationHandler(self.http_response, self.no_validation)
 
+    def get_spec(self):
+        """
+        TODO
+        :return:
+        """
+        return self.spec
+
     def parse(self):
         """
         TODO

--- a/w3af/core/data/parsers/doc/open_api/specification.py
+++ b/w3af/core/data/parsers/doc/open_api/specification.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 """
-requests.py
+specification.py
 
 Copyright 2017 Andres Riancho
 
@@ -50,32 +50,34 @@ for to_silence in SILENCE:
 
 
 class SpecificationHandler(object):
+
     def __init__(self, http_response, no_validation=False):
         self.http_response = http_response
-        self.spec = None
         self.no_validation = no_validation
+        self.spec = None
 
     def get_http_response(self):
         return self.http_response
 
     def shallow_copy(self):
         """
-        TODO
-        :return:
+        :return: A copy of the SpecificationHandler
+                 which doesn't contain a Spec instance.
         """
         return SpecificationHandler(self.http_response, self.no_validation)
 
     def get_spec(self):
         """
-        TODO
-        :return:
+        :return: An instance of Spec (Bravado)
+                 which was created by this SpecificationHandler.
         """
         return self.spec
 
     def parse(self):
         """
-        TODO
-        :return:
+        Parse an API specification provided in the HTTP response.
+
+        :return: An instance of Spec (Bravado).
         """
         spec_dict = self._load_spec_dict()
         if spec_dict is None:

--- a/w3af/plugins/audit/open_api_auth.py
+++ b/w3af/plugins/audit/open_api_auth.py
@@ -1,0 +1,113 @@
+"""
+open_api_auth.py
+
+Copyright 2018 Andres Riancho
+
+This file is part of w3af, http://w3af.org/ .
+
+w3af is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation version 2 of the License.
+
+w3af is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with w3af; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+"""
+from w3af.core.controllers.plugins.audit_plugin import AuditPlugin
+
+import w3af.core.data.kb.knowledge_base as kb
+import w3af.core.controllers.output_manager as om
+from w3af.core.data.parsers.doc.open_api.specification import SpecificationHandler
+
+
+class open_api_auth(AuditPlugin):
+    """
+    TODO
+
+    :author: Artem Smotrakov (artem.smotrakov@gmail.com)
+    :author: Andres Riancho (andres.riancho@gmail.com)
+    """
+
+    def __init__(self):
+        AuditPlugin.__init__(self)
+        self._spec = None
+
+    def audit(self, freq, orig_response, debugging_id):
+        """
+        TODO
+
+        :param freq: A FuzzableRequest
+        :param orig_response: The HTTP response associated with the fuzzable request
+        :param debugging_id: A unique identifier for this call to audit()
+        """
+        if self._has_no_api_spec():
+            om.out.info("could not find an API specification, skip")
+            return
+
+        if self._no_security_in_spec():
+            om.out.info("the API spec defines no security, skip")
+            return
+
+
+        # TODO The check should only work when the open api specification requires authentication for a endpoint
+        #      Check for security headers according to the spec
+        if self._should_skip(freq):
+            return
+
+        # TODO The check should send a request for each authenticated endpoint using the provided authentication,
+        # then send it without the provided authentication and compare both.If they are similar (see fuzzy_equal)
+        # then a vulnerability should be reported.
+
+    def _analyze_result(self, mutant, response):
+        """
+        Analyze results of the _send_mutant method.
+        """
+        pass
+
+    # TODO The check should only work when the user configures authentication (api key, headers, etc.)
+    def _no_security_in_spec(self):
+        """
+        TODO
+        :return:
+        """
+        return True
+
+    def _has_no_api_spec(self):
+        """
+        TODO
+        :return:
+        """
+        if self._spec:
+            return False
+
+        specification_handler = kb.kb.raw_read('open_api', 'specification_handler')
+        if not specification_handler:
+            return True
+
+        self._spec = specification_handler.parse()
+
+        if not self._spec:
+            return True
+
+        return False
+
+    def _should_skip(self, freq):
+        """
+        TODO
+        :return:
+        """
+        return True
+
+    def get_long_desc(self):
+        """
+        :return: A DETAILED description of the plugin functions and features.
+        """
+        return """
+        TODO
+        """

--- a/w3af/plugins/audit/open_api_auth.py
+++ b/w3af/plugins/audit/open_api_auth.py
@@ -66,6 +66,13 @@ class open_api_auth(AuditPlugin):
         self._spec = None
         self._expected_codes = [401]
 
+    def get_plugin_deps(self):
+        """
+        :return: A list with the names of the plugins
+                 that should be run before the current one.
+        """
+        return ['crawl.open_api']
+
     def audit(self, freq, orig_response, debugging_id):
         """
         Check if an API endpoint requires authentication according to its API spec.
@@ -365,7 +372,7 @@ class open_api_auth(AuditPlugin):
           * Check if the response has 401 error code (access denied).
 
         A couple of important notes:
-          * The plugin requires the 'crawl.open_api' plugin to be enabled.
+          * The plugin enables the 'crawl.open_api' plugin.
             It works only with REST API endpoints.
           * The check works only when API specification requires authentication for a endpoint.
           * The check works only if a user provided authentication info (API key, header, etc).

--- a/w3af/plugins/audit/open_api_auth.py
+++ b/w3af/plugins/audit/open_api_auth.py
@@ -208,23 +208,27 @@ class open_api_auth(AuditPlugin):
 
         return False
 
-    @staticmethod
-    def _has_basic_auth(freq):
+    def _has_basic_auth(self, freq):
         """
         TODO
         :param freq:
         :return:
         """
+        if not self._is_acceptable_auth_type(freq, 'basic'):
+            return False
+
         return freq.get_headers().iget('Authorization', '')[0].startswith('basic')
 
-    @staticmethod
-    def _has_api_key(freq, auth):
+    def _has_api_key(self, freq, auth):
         """
         TODO
         :param freq:
         :param auth:
         :return:
         """
+        if not self._is_acceptable_auth_type(freq, 'apiKey'):
+            return False
+
         if not hasattr(auth, 'name'):
             return False
 
@@ -239,6 +243,17 @@ class open_api_auth(AuditPlugin):
             return True
 
         return False
+
+    def _has_oauth2(self, freq):
+        """
+        TODO
+        :param freq:
+        :return:
+        """
+        if not self._is_acceptable_auth_type(freq, 'oauth2'):
+            return False
+
+        return freq.get_headers().iget('Authorization', '')[0].startswith('Bearer')
 
     def _is_acceptable_auth_type(self, freq, auth_type):
         """
@@ -263,17 +278,6 @@ class open_api_auth(AuditPlugin):
                     return True
 
         return False
-
-    def _has_oauth2(self, freq):
-        """
-        TODO
-        :param freq:
-        :return:
-        """
-        if not self._is_acceptable_auth_type(freq, 'oauth2'):
-            return False
-
-        return freq.get_headers().iget('Authorization', '')[0].startswith('Bearer')
 
     def get_long_desc(self):
         """

--- a/w3af/plugins/audit/open_api_auth.py
+++ b/w3af/plugins/audit/open_api_auth.py
@@ -49,12 +49,12 @@ class open_api_auth(AuditPlugin):
         # The check works only with API endpoints.
         # crawl.open_api plugin has to be called before.
         if not self._has_api_spec():
-            om.out.info("Could not find an API specification, skip")
+            om.out.information("Could not find an API specification, skip")
             return
 
         # The API spec must define authentication mechanisms.
         if not self._has_security_definitions_in_spec():
-            om.out.info("The API spec has no security definitions, skip")
+            om.out.information("The API spec has no security definitions, skip")
             return
 
         # The check only runs if the open api specification
@@ -62,7 +62,7 @@ class open_api_auth(AuditPlugin):
         # TODO: take into account `security` section for an operation (or there may be a global one)
         #       https://swagger.io/docs/specification/2-0/authentication/
         if not self._has_auth(freq):
-            om.out.info("Request doesn't have auth info, skip")
+            om.out.information("Request doesn't have auth info, skip")
             return
 
         # Remove auth info from the request
@@ -155,13 +155,13 @@ class open_api_auth(AuditPlugin):
         :param auth:
         :return:
         """
-        if auth['in'] == 'query':
+        if auth.location == 'query':
             params = freq.get_url().get_params()
             del params[auth.name]
             freq.get_url().set_params(params)
 
-        if auth['in'] == 'header':
-            self._remove_header(freq, auth['name'])
+        if auth.location == 'header':
+            self._remove_header(freq, auth.name)
 
     def _has_auth(self, freq):
         """
@@ -182,21 +182,21 @@ class open_api_auth(AuditPlugin):
 
     @staticmethod
     def _has_basic_auth(freq):
-        return freq.get_headers().iget('Authorization', '').startswith('basic')
+        return freq.get_headers().iget('Authorization', '')[0].startswith('basic')
 
     @staticmethod
     def _has_api_key(freq, auth):
         if not hasattr(auth, 'name'):
             return False
 
-        if not hasattr(auth, 'in'):
+        if not hasattr(auth, 'location'):
             return False
 
-        if auth['in'] == 'query':
+        if auth.location == 'query':
             params = freq.get_url().get_params()
             return params and auth.name in params and params[auth.name]
 
-        if auth['in'] == 'header' and freq.get_headers().iget(auth.name):
+        if auth.location == 'header' and freq.get_headers().iget(auth.name)[0]:
             return True
 
         return False

--- a/w3af/plugins/audit/open_api_auth.py
+++ b/w3af/plugins/audit/open_api_auth.py
@@ -19,11 +19,12 @@ along with w3af; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 """
-from w3af.core.controllers.plugins.audit_plugin import AuditPlugin
+import copy
 
 import w3af.core.data.kb.knowledge_base as kb
 import w3af.core.controllers.output_manager as om
-from w3af.core.data.parsers.doc.open_api.specification import SpecificationHandler
+
+from w3af.core.controllers.plugins.audit_plugin import AuditPlugin
 
 
 class open_api_auth(AuditPlugin):
@@ -41,68 +42,168 @@ class open_api_auth(AuditPlugin):
     def audit(self, freq, orig_response, debugging_id):
         """
         TODO
-
         :param freq: A FuzzableRequest
         :param orig_response: The HTTP response associated with the fuzzable request
         :param debugging_id: A unique identifier for this call to audit()
         """
-        if self._has_no_api_spec():
-            om.out.info("could not find an API specification, skip")
+        # The check works only with API endpoints.
+        # crawl.open_api plugin has to be called before.
+        if not self._has_api_spec():
+            om.out.info("Could not find an API specification, skip")
             return
 
-        if self._no_security_in_spec():
-            om.out.info("the API spec defines no security, skip")
+        # The API spec must define authentication mechanisms.
+        if not self._has_security_definitions_in_spec():
+            om.out.info("The API spec has no security definitions, skip")
             return
 
-
-        # TODO The check should only work when the open api specification requires authentication for a endpoint
-        #      Check for security headers according to the spec
-        if self._should_skip(freq):
+        # The check only runs if the open api specification
+        # requires authentication for a endpoint.
+        # TODO: take into account `security` section for an operation (or there may be a global one)
+        #       https://swagger.io/docs/specification/2-0/authentication/
+        if not self._has_auth(freq):
+            om.out.info("Request doesn't have auth info, skip")
             return
 
-        # TODO The check should send a request for each authenticated endpoint using the provided authentication,
-        # then send it without the provided authentication and compare both.If they are similar (see fuzzy_equal)
-        # then a vulnerability should be reported.
+        # Remove auth info from the request
+        freq_with_no_auth = self._remove_auth(freq)
 
-    def _analyze_result(self, mutant, response):
+        # Send the request to the server, and check if access was denied.
+        self._uri_opener.send_mutant(freq_with_no_auth,
+                                     callback=self._check_access_denied,
+                                     debugging_id=debugging_id)
+
+        # TODO consider sending requests with other HTTP methods,
+        #      and check that 401 or 405 error code is returned
+        #      On the one hand, it may not look too good if we just replace the method,
+        #      and keep the rest of the request untouched (headers, payload, etc).
+        #      But on the other hand, the application is supposed to check HTTP method in the very beginning,
+        #      and reject requests if the method is not supported.
+        #      If the API spec says a particular method is supported, then the check should expect 401
+        #      If the API spec says a particular method is not supported,
+        #      then the check should expect 405 (preferred) or 401 (should it only expect 405 in this case?).
+
+        # TODO Should we compare the response with orig_response (see fuzzy_equal),
+        #      and report a vulnerability if they are similar?
+        #      Or, just checking the response code is enough?
+
+    def _check_access_denied(self, freq, response):
         """
-        Analyze results of the _send_mutant method.
+        TODO
         """
         pass
 
-    # TODO The check should only work when the user configures authentication (api key, headers, etc.)
-    def _no_security_in_spec(self):
+    def _has_security_definitions_in_spec(self):
         """
         TODO
         :return:
         """
-        return True
+        if self._spec.security_definitions:
+            return True
 
-    def _has_no_api_spec(self):
+        return False
+
+    def _has_api_spec(self):
         """
         TODO
         :return:
         """
         if self._spec:
-            return False
+            return True
 
         specification_handler = kb.kb.raw_read('open_api', 'specification_handler')
         if not specification_handler:
-            return True
+            return False
 
         self._spec = specification_handler.parse()
-
-        if not self._spec:
+        if self._spec:
             return True
 
         return False
 
-    def _should_skip(self, freq):
+    def _remove_auth(self, freq):
+        """
+        TODO
+        :param freq:
+        :return:
+        """
+        updated_freq = copy.deepcopy(freq)
+        for key, auth in self._spec.security_definitions.iteritems():
+            if auth.type == 'basic' or auth.type == 'oauth2':
+                self._remove_header(updated_freq, 'Authorization')
+
+            if auth.type == 'apiKey':
+                self._remove_api_key(updated_freq, auth)
+
+        return updated_freq
+
+    @staticmethod
+    def _remove_header(freq, name):
+        """
+        TODO
+        :param freq:
+        :return:
+        """
+        headers = freq.get_headers()
+        if headers.icontains(name):
+            headers.idel(name)
+
+    def _remove_api_key(self, freq, auth):
+        """
+        TODO
+        :param freq:
+        :param auth:
+        :return:
+        """
+        if auth['in'] == 'query':
+            params = freq.get_url().get_params()
+            del params[auth.name]
+            freq.get_url().set_params(params)
+
+        if auth['in'] == 'header':
+            self._remove_header(freq, auth['name'])
+
+    def _has_auth(self, freq):
         """
         TODO
         :return:
         """
-        return True
+        for key, auth in self._spec.security_definitions.iteritems():
+            if auth.type == 'basic' and self._has_basic_auth(freq):
+                return True
+
+            if auth.type == 'apiKey' and self._has_api_key(freq, auth):
+                return True
+
+            if auth.type == 'oauth2' and self._has_oauth2(freq):
+                return True
+
+        return False
+
+    @staticmethod
+    def _has_basic_auth(freq):
+        return freq.get_headers().iget('Authorization', '').startswith('basic')
+
+    @staticmethod
+    def _has_api_key(freq, auth):
+        if not hasattr(auth, 'name'):
+            return False
+
+        if not hasattr(auth, 'in'):
+            return False
+
+        if auth['in'] == 'query':
+            params = freq.get_url().get_params()
+            return params and auth.name in params and params[auth.name]
+
+        if auth['in'] == 'header' and freq.get_headers().iget(auth.name):
+            return True
+
+        return False
+
+    @staticmethod
+    def _has_oauth2(freq):
+        return freq.get_headers().iget('Authorization', '')[0].startswith('Bearer')
 
     def get_long_desc(self):
         """

--- a/w3af/plugins/crawl/open_api.py
+++ b/w3af/plugins/crawl/open_api.py
@@ -237,12 +237,19 @@ class open_api(CrawlPlugin):
         # Save a shallow copy of the specification handler to the kb.
         # It would be better to save the API spec
         # but looks like pickling doesn't work well with Bravado.
-        kb.kb.raw_write('open_api', 'specification_handler',
-                        parser.get_specification_handler().shallow_copy())
+        specification_handlers = kb.kb.raw_read('open_api', 'specification_handlers')
+        if not specification_handlers:
+            specification_handlers = []
+        specification_handlers.append(parser.get_specification_handler().shallow_copy())
+        kb.kb.raw_write('open_api', 'specification_handlers', specification_handlers)
 
         # Store the operation ids in the kb.
-        kb.kb.raw_write('open_api', 'request_to_operation_id',
-                        parser.get_request_to_operation_id())
+        request_to_operation_id = kb.kb.raw_read('open_api', 'request_to_operation_id')
+        if not request_to_operation_id:
+            request_to_operation_id = {}
+        for method_and_url, operation_id in parser.get_request_to_operation_id().iteritems():
+            request_to_operation_id[method_and_url] = operation_id
+        kb.kb.raw_write('open_api', 'request_to_operation_id', request_to_operation_id)
 
         # Warn the user about missing credentials
         if self._query_string_auth or self._header_auth:

--- a/w3af/plugins/crawl/open_api.py
+++ b/w3af/plugins/crawl/open_api.py
@@ -230,6 +230,11 @@ class open_api(CrawlPlugin):
         kb.kb.append(self, 'open_api', i)
         om.out.information(i.get_desc())
 
+        # Save a shallow copy of the specification handler to the kb.
+        # It would be better to save the API spec
+        # but looks like pickling doesn't work well with Bravado.
+        kb.kb.raw_write('open_api', 'specification_handler', parser.get_specification_handler().shallow_copy())
+
         # Warn the user about missing credentials
         if self._query_string_auth or self._header_auth:
             return

--- a/w3af/plugins/crawl/open_api.py
+++ b/w3af/plugins/crawl/open_api.py
@@ -233,7 +233,12 @@ class open_api(CrawlPlugin):
         # Save a shallow copy of the specification handler to the kb.
         # It would be better to save the API spec
         # but looks like pickling doesn't work well with Bravado.
-        kb.kb.raw_write('open_api', 'specification_handler', parser.get_specification_handler().shallow_copy())
+        kb.kb.raw_write('open_api', 'specification_handler',
+                        parser.get_specification_handler().shallow_copy())
+
+        # Store the operation ids in the kb.
+        kb.kb.raw_write('open_api', 'request_to_operation_id',
+                        parser.get_request_to_operation_id())
 
         # Warn the user about missing credentials
         if self._query_string_auth or self._header_auth:

--- a/w3af/plugins/tests/audit/data/petstore_with_security.yaml
+++ b/w3af/plugins/tests/audit/data/petstore_with_security.yaml
@@ -58,6 +58,7 @@ paths:
           format: int32
       security:
         - ApiKeyAuth: []
+        - OAuth2: [read]
       responses:
         "200":
           description: pet response
@@ -81,6 +82,7 @@ paths:
             $ref: '#/definitions/NewPet'
       security:
         - ApiKeyAuth: []
+        - OAuth2: [write]
       responses:
         "200":
           description: pet response
@@ -93,14 +95,14 @@ paths:
   /pets/{id}:
     get:
       description: Returns a pet
-      operationId: find pet by id
+      operationId: findPetById
       parameters:
-      - name: id
-        in: path
-        description: ID of pet to fetch
-        required: true
-        type: integer
-        format: int64
+        - name: id
+          in: path
+          description: ID of pet to fetch
+          required: true
+          type: integer
+          format: int64
       responses:
         "200":
           description: pet response

--- a/w3af/plugins/tests/audit/data/petstore_with_security.yaml
+++ b/w3af/plugins/tests/audit/data/petstore_with_security.yaml
@@ -1,0 +1,142 @@
+swagger: "2.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Swagger API Team
+    email: foo@example.com
+    url: http://madskristensen.net
+  license:
+    name: MIT
+    url: http://github.com/gruntjs/grunt/blob/master/LICENSE-MIT
+host: w3af.org
+basePath: /api
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+securityDefinitions:
+  ApiKeyAuth:
+    type: apiKey
+    in: header
+    name: X-API-Key
+  OAuth2:
+    type: oauth2
+    flow: accessCode
+    authorizationUrl: https://example.com/oauth/authorize
+    tokenUrl: https://example.com/oauth/token
+    scopes:
+      read:  Grants read access
+      write: Grants write access
+security:
+  - OAuth2: [read, write]
+paths:
+  /ping:
+    get:
+      description: Checks if the server is running
+      operationId: ping
+      security: []
+      responses:
+        "200":
+          description: Server is up and running
+        default:
+          description: Something is wrong
+  /pets:
+    get:
+      description: Returns all pets from the system that the user has access to
+      operationId: findPets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          type: integer
+          format: int32
+      security:
+        - ApiKeyAuth: []
+      responses:
+        "200":
+          description: pet response
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Pet'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      description: Creates a new pet in the store.  Duplicates are allowed
+      operationId: addPet
+      parameters:
+        - name: pet
+          in: body
+          description: Pet to add to the store
+          required: true
+          schema:
+            $ref: '#/definitions/NewPet'
+      security:
+        - ApiKeyAuth: []
+      responses:
+        "200":
+          description: pet response
+          schema:
+            $ref: '#/definitions/Pet'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /pets/{id}:
+    get:
+      description: Returns a pet
+      operationId: find pet by id
+      parameters:
+      - name: id
+        in: path
+        description: ID of pet to fetch
+        required: true
+        type: integer
+        format: int64
+      responses:
+        "200":
+          description: pet response
+          schema:
+            $ref: '#/definitions/Pet'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+definitions:
+  Pet:
+    allOf:
+      - $ref: '#/definitions/NewPet'
+      - required:
+          - id
+        properties:
+          id:
+            type: integer
+            format: int64
+
+  NewPet:
+    required:
+      - name
+    properties:
+      name:
+        type: string
+      tag:
+        type: string
+
+  Error:
+    required:
+      - code
+      - message
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string

--- a/w3af/plugins/tests/audit/data/petstore_with_security.yaml
+++ b/w3af/plugins/tests/audit/data/petstore_with_security.yaml
@@ -124,6 +124,7 @@ definitions:
             format: int64
 
   NewPet:
+    type: object
     required:
       - name
     properties:
@@ -133,6 +134,7 @@ definitions:
         type: string
 
   Error:
+    type: object
     required:
       - code
       - message

--- a/w3af/plugins/tests/audit/data/users_with_security.yaml
+++ b/w3af/plugins/tests/audit/data/users_with_security.yaml
@@ -1,0 +1,69 @@
+swagger: "2.0"
+info:
+  version: 1.0.0
+  title: Users
+  description: A sample API for a user directory
+host: w3af.org
+basePath: /api
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+securityDefinitions:
+  ApiKeyAuth:
+    type: apiKey
+    in: header
+    name: X-API-Key
+  basicAuth:
+    type: basic
+security:
+  - basicAuth: []
+paths:
+  /users:
+    get:
+      description: Returns all users
+      operationId: findUsers
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          type: integer
+          format: int32
+      security:
+        - ApiKeyAuth: []
+      responses:
+        "200":
+          description: user
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/User'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+definitions:
+  User:
+    type: object
+    required:
+      - name
+    properties:
+      name:
+        type: string
+      address:
+        type: string
+
+  Error:
+    type: object
+    required:
+      - code
+      - message
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string

--- a/w3af/plugins/tests/audit/test_open_api_auth.py
+++ b/w3af/plugins/tests/audit/test_open_api_auth.py
@@ -123,7 +123,7 @@ class TestOpenAPIAuth(PluginTest):
         fuzzable_requests = self.kb.get_all_known_fuzzable_requests()
         fuzzable_requests = [f for f in fuzzable_requests if f.get_url().get_path() not in ('/openapi.yaml', '/')]
         fuzzable_requests.sort(by_path)
-        self.assertEqual(len(fuzzable_requests), 4)
+        self.assertEqual(len(fuzzable_requests), 6)
 
         # TODO check for vulns
         # vulns = self.kb.get('open_api_auth', 'open_api_auth')
@@ -223,15 +223,14 @@ class TestOpenAPIAuth(PluginTest):
                              post_data=KeyValueContainer(),
                              method='POST')
 
-        # TODO figure out why it doesn't have POST method for /api/pets
-        #self.assertTrue(plugin._is_acceptable_auth_type(fr, 'oauth2'))
-        #self.assertTrue(plugin._is_acceptable_auth_type(fr, 'apiKey'))
-        #self.assertFalse(plugin._is_acceptable_auth_type(fr, 'basic'))
-        #self.assertFalse(plugin._is_acceptable_auth_type(fr, 'unknown'))
-        #self.assertTrue(plugin._has_auth(fr))
-        #self.assertFalse(plugin._has_oauth2(fr))
-        #self.assertTrue(plugin._has_api_key(fr, spec.security_definitions['ApiKeyAuth']))
-        #self.assertFalse(plugin._has_basic_auth(fr))
+        self.assertTrue(plugin._is_acceptable_auth_type(fr, 'oauth2'))
+        self.assertTrue(plugin._is_acceptable_auth_type(fr, 'apiKey'))
+        self.assertFalse(plugin._is_acceptable_auth_type(fr, 'basic'))
+        self.assertFalse(plugin._is_acceptable_auth_type(fr, 'unknown'))
+        self.assertTrue(plugin._has_auth(fr))
+        self.assertFalse(plugin._has_oauth2(fr))
+        self.assertTrue(plugin._has_api_key(fr, spec.security_definitions['ApiKeyAuth']))
+        self.assertFalse(plugin._has_basic_auth(fr))
 
         # Check the endpoint which doesn't require auth.
         fr = FuzzableRequest(URL('http://w3af.org/api/ping'),

--- a/w3af/plugins/tests/audit/test_open_api_auth.py
+++ b/w3af/plugins/tests/audit/test_open_api_auth.py
@@ -1,0 +1,199 @@
+"""
+test_open_api_auth.py
+
+Copyright 2018 Andres Riancho
+
+This file is part of w3af, http://w3af.org/ .
+
+w3af is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation version 2 of the License.
+
+w3af is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with w3af; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+"""
+import os
+
+from w3af.core.data.dc.generic.kv_container import KeyValueContainer
+from w3af.core.data.dc.headers import Headers
+
+from w3af.core.data.parsers.doc.open_api.specification import SpecificationHandler
+from w3af.core.data.parsers.doc.url import URL
+from w3af.core.data.request.fuzzable_request import FuzzableRequest
+from w3af.core.data.url.HTTPResponse import HTTPResponse
+from w3af.plugins.audit.open_api_auth import open_api_auth
+from w3af.plugins.tests.helper import PluginTest, PluginConfig, MockResponse
+
+
+CURRENT_PATH = os.path.split(__file__)[0]
+
+
+def by_path(fra, frb):
+    return cmp(fra.get_url().url_string, frb.get_url().url_string)
+
+
+def generate_response(specification_as_string):
+    url = URL('http://www.w3af.com/openapi.yaml')
+    headers = Headers([('content-type', 'application/yaml')])
+    return HTTPResponse(200, specification_as_string, headers,
+                        url, url, _id=1)
+
+
+class AuthMockResponse(MockResponse):
+
+    def get_response(self, http_request, uri, response_headers):
+        if http_request.headers.get('X-API-Key', '') != 'xxx':
+            return 401, response_headers, ''
+
+        return super(AuthMockResponse, self).get_response(http_request,
+                                                          uri,
+                                                          response_headers)
+
+
+class PetstoreWithSecurity(object):
+
+    @staticmethod
+    def get_specification():
+        return file('%s/data/petstore_with_security.yaml' % CURRENT_PATH).read()
+
+
+class TestOpenAPIAuth(PluginTest):
+
+    target_url = 'http://w3af.org/'
+    api_key_auth = ('header_auth', 'X-API-Key: xxx', PluginConfig.HEADER)
+
+    _run_configs = {
+        'cfg': {
+            'target': target_url,
+            'plugins': {
+                'crawl': (PluginConfig('open_api', api_key_auth,),),
+                'audit': (PluginConfig('open_api_auth'),)
+            }
+        }
+    }
+
+    MOCK_RESPONSES = [MockResponse('http://w3af.org/openapi.yaml',
+                                   PetstoreWithSecurity().get_specification(),
+                                   content_type='application/yaml'),
+                      MockResponse('http://w3af.org/api/ping',
+                                   '',
+                                   content_type='text/plain'),
+                      MockResponse('http://w3af.org/api/pets',
+                                   '{ "id": 42 }',
+                                   content_type='application/json'),
+                      AuthMockResponse('http://w3af.org/api/pets/*',
+                                       '{ "id": 42 }',
+                                       content_type='application/json')
+                      ]
+
+    def test_petstore_with_security(self):
+        cfg = self._run_configs['cfg']
+        self._scan(cfg['target'], cfg['plugins'])
+
+        specification_handler = self.kb.raw_read('open_api', 'specification_handler')
+        self.assertIsNotNone(specification_handler, "no specification handler")
+        self.assertTrue(isinstance(specification_handler, SpecificationHandler), "not a SpecificationHandler")
+
+        infos = self.kb.get('open_api', 'open_api')
+        self.assertEqual(len(infos), 1, infos)
+        info_i = infos[0]
+        self.assertEqual(info_i.get_name(), 'Open API specification found')
+
+        fuzzable_requests = self.kb.get_all_known_fuzzable_requests()
+        fuzzable_requests = [f for f in fuzzable_requests if f.get_url().get_path() not in ('/openapi.yaml', '/')]
+        fuzzable_requests.sort(by_path)
+        self.assertEqual(len(fuzzable_requests), 4)
+
+        # TODO check for vulns
+        # vulns = self.kb.get('open_api_auth', 'open_api_auth')
+        # self.assertEquals(len(vulns), 1)
+        # vuln = vulns[0]
+        # self.assertEquals('TBD', vuln.get_name())
+        # self.assertEquals('TBD', vuln.get_url().url_string)
+
+    def test_open_api_auth(self):
+        api_http_response = generate_response(PetstoreWithSecurity.get_specification())
+        specification_handler = SpecificationHandler(api_http_response)
+        self.kb.raw_write('open_api', 'specification_handler', specification_handler)
+
+        spec = specification_handler.parse()
+
+        plugin = open_api_auth()
+        self.assertTrue(plugin._has_api_spec())
+        self.assertTrue(plugin._has_security_definitions_in_spec())
+
+        url = URL('http://w3af.org/api/pets')
+
+        fr = FuzzableRequest(url,
+                             headers=Headers([('Authorization', 'Bearer xxx')]),
+                             post_data=KeyValueContainer(),
+                             method='GET')
+        self.assertTrue(plugin._has_auth(fr))
+        self.assertTrue(plugin._has_oauth2(fr))
+        self.assertFalse(plugin._has_api_key(fr, spec.security_definitions['ApiKeyAuth']))
+        self.assertFalse(plugin._has_basic_auth(fr))
+
+        # Remove auth info from the request.
+        updated_fr = plugin._remove_auth(fr)
+
+        # Make sure that the original request still has auth info.
+        self.assertTrue(plugin._has_auth(fr))
+        self.assertTrue(plugin._has_oauth2(fr))
+        self.assertFalse(plugin._has_api_key(fr, spec.security_definitions['ApiKeyAuth']))
+        self.assertFalse(plugin._has_basic_auth(fr))
+
+        # Check if the updated request doesn't have auth info.
+        self.assertFalse(plugin._has_auth(updated_fr))
+        self.assertFalse(plugin._has_api_key(updated_fr, spec.security_definitions['ApiKeyAuth']))
+        self.assertFalse(plugin._has_oauth2(updated_fr))
+        self.assertFalse(plugin._has_basic_auth(updated_fr))
+
+        fr = FuzzableRequest(url,
+                             headers=Headers([('X-API-Key', 'zzz')]),
+                             post_data=KeyValueContainer(),
+                             method='POST')
+        self.assertTrue(plugin._has_auth(fr))
+        self.assertTrue(plugin._has_api_key(fr, spec.security_definitions['ApiKeyAuth']))
+        self.assertFalse(plugin._has_oauth2(fr))
+        self.assertFalse(plugin._has_basic_auth(fr))
+
+        # Remove auth info from the request.
+        updated_fr = plugin._remove_auth(fr)
+
+        # Make sure that the original request still has auth info.
+        self.assertTrue(plugin._has_auth(fr))
+        self.assertTrue(plugin._has_api_key(fr, spec.security_definitions['ApiKeyAuth']))
+        self.assertFalse(plugin._has_oauth2(fr))
+        self.assertFalse(plugin._has_basic_auth(fr))
+
+        # Check if the updated request doesn't have auth info.
+        self.assertFalse(plugin._has_auth(updated_fr))
+        self.assertFalse(plugin._has_api_key(updated_fr, spec.security_definitions['ApiKeyAuth']))
+        self.assertFalse(plugin._has_oauth2(updated_fr))
+        self.assertFalse(plugin._has_basic_auth(updated_fr))
+
+        fr = FuzzableRequest(url,
+                             headers=Headers([('X-Foo-Header', 'foo'), ('X-Bar-Header', 'bar')]),
+                             post_data=KeyValueContainer(),
+                             method='PUT')
+        self.assertFalse(plugin._has_auth(fr))
+        self.assertFalse(plugin._has_api_key(fr, spec.security_definitions['ApiKeyAuth']))
+        self.assertFalse(plugin._has_oauth2(fr))
+        self.assertFalse(plugin._has_basic_auth(fr))
+
+        # Remove auth info from the request.
+        updated_fr = plugin._remove_auth(fr)
+        self.assertFalse(plugin._has_auth(updated_fr))
+        self.assertFalse(plugin._has_api_key(updated_fr, spec.security_definitions['ApiKeyAuth']))
+        self.assertFalse(plugin._has_oauth2(updated_fr))
+        self.assertFalse(plugin._has_basic_auth(updated_fr))
+
+        open_api_auth._remove_header(fr, 'X-Bar-Header')
+        self.assertFalse(fr.get_headers().icontains('X-Bar-Header'))
+        self.assertTrue(fr.get_headers().icontains('X-Foo-Header'))

--- a/w3af/plugins/tests/audit/test_open_api_auth.py
+++ b/w3af/plugins/tests/audit/test_open_api_auth.py
@@ -154,6 +154,7 @@ class TestOpenAPIAuth(PluginTest):
         self.assertTrue(plugin._is_acceptable_auth_type(fr, 'apiKey'))
         self.assertFalse(plugin._is_acceptable_auth_type(fr, 'basic'))
         self.assertFalse(plugin._is_acceptable_auth_type(fr, 'unknown'))
+
         self.assertTrue(plugin._has_auth(fr))
         self.assertTrue(plugin._has_oauth2(fr))
         self.assertFalse(plugin._has_api_key(fr, spec.security_definitions['ApiKeyAuth']))
@@ -178,6 +179,12 @@ class TestOpenAPIAuth(PluginTest):
                              headers=Headers([('X-API-Key', 'zzz')]),
                              post_data=KeyValueContainer(),
                              method='POST')
+
+        self.assertTrue(plugin._is_acceptable_auth_type(fr, 'oauth2'))
+        self.assertTrue(plugin._is_acceptable_auth_type(fr, 'apiKey'))
+        self.assertFalse(plugin._is_acceptable_auth_type(fr, 'basic'))
+        self.assertFalse(plugin._is_acceptable_auth_type(fr, 'unknown'))
+
         self.assertTrue(plugin._has_auth(fr))
         self.assertTrue(plugin._has_api_key(fr, spec.security_definitions['ApiKeyAuth']))
         self.assertFalse(plugin._has_oauth2(fr))
@@ -244,5 +251,22 @@ class TestOpenAPIAuth(PluginTest):
         self.assertFalse(plugin._is_acceptable_auth_type(fr, 'unknown'))
         self.assertFalse(plugin._has_auth(fr))
         self.assertFalse(plugin._has_oauth2(fr))
+        self.assertFalse(plugin._has_api_key(fr, spec.security_definitions['ApiKeyAuth']))
+        self.assertFalse(plugin._has_basic_auth(fr))
+
+        # /api/pets/{id} doesn't have a 'security' section
+        # but global 'security' section should apply here (only OAuth2)
+        fr = FuzzableRequest(URL('http://w3af.org/api/pets/42'),
+                             headers=Headers([('Authorization', 'Bearer xxx')]),
+                             post_data=KeyValueContainer(),
+                             method='GET')
+
+        self.assertTrue(plugin._is_acceptable_auth_type(fr, 'oauth2'))
+        self.assertFalse(plugin._is_acceptable_auth_type(fr, 'apiKey'))
+        self.assertFalse(plugin._is_acceptable_auth_type(fr, 'basic'))
+        self.assertFalse(plugin._is_acceptable_auth_type(fr, 'unknown'))
+
+        self.assertTrue(plugin._has_auth(fr))
+        self.assertTrue(plugin._has_oauth2(fr))
         self.assertFalse(plugin._has_api_key(fr, spec.security_definitions['ApiKeyAuth']))
         self.assertFalse(plugin._has_basic_auth(fr))

--- a/w3af/plugins/tests/audit/test_open_api_auth.py
+++ b/w3af/plugins/tests/audit/test_open_api_auth.py
@@ -153,7 +153,7 @@ class TestOpenAPIAuth(PluginTest):
         spec = parser.get_specification_handler().get_spec()
 
         plugin = open_api_auth()
-        self.assertTrue(plugin._has_api_spec())
+        self.assertTrue(plugin._is_api_spec_available())
         self.assertTrue(plugin._has_security_definitions_in_spec())
 
         return plugin, spec

--- a/w3af/plugins/tests/audit/test_open_api_auth.py
+++ b/w3af/plugins/tests/audit/test_open_api_auth.py
@@ -112,11 +112,16 @@ class TestOpenAPIAuthWithPetstore(PluginTest):
         cfg = self._run_configs['cfg']
         self._scan(cfg['target'], cfg['plugins'])
 
-        specification_handler = self.kb.raw_read('open_api',
-                                                 'specification_handler')
-        self.assertIsNotNone(specification_handler, "no specification handler")
+        specification_handlers = self.kb.raw_read('open_api',
+                                                  'specification_handlers')
+        self.assertIsNotNone(specification_handlers, 'no specification handlers (none)')
+        self.assertTrue(isinstance(specification_handlers, list),
+                        'not a list of SpecificationHandler')
+        self.assertEquals(len(specification_handlers), 1)
+
+        specification_handler = specification_handlers[0]
         self.assertTrue(isinstance(specification_handler, SpecificationHandler),
-                        "not a SpecificationHandler")
+                        'not a SpecificationHandler')
 
         infos = self.kb.get('open_api', 'open_api')
         self.assertEqual(len(infos), 1, infos)
@@ -145,8 +150,8 @@ class TestOpenAPIAuth(PluginTest):
         api_http_response = generate_response(PetstoreWithSecurity.get_specification())
         parser = OpenAPI(api_http_response)
         parser.parse()
-        self.kb.raw_write('open_api', 'specification_handler',
-                          parser.get_specification_handler().shallow_copy())
+        self.kb.raw_write('open_api', 'specification_handlers',
+                          [parser.get_specification_handler().shallow_copy()])
         self.kb.raw_write('open_api', 'request_to_operation_id',
                           parser.get_request_to_operation_id())
 
@@ -154,7 +159,6 @@ class TestOpenAPIAuth(PluginTest):
 
         plugin = open_api_auth()
         self.assertTrue(plugin._is_api_spec_available())
-        self.assertTrue(plugin._has_security_definitions_in_spec())
 
         return plugin, spec
 


### PR DESCRIPTION
This pull request introduces a new plugin `audit.open_api_auth` which is described in #17343 

Implementation notes:

- The new plugin works only with API endpoints. It requires an API specification which has to be provided by `crawl.open_api` plugin.
- The `crawl.open_api` plugin shares API specification via the knowledge base.
- The new plugin simply checks that endpoints return 401 error if no authentication info is provided in the request.

Please consider it as a first version of the plugin. I was going to make the plugin smaller but it turned out that it needs quite a lot of checks, so now the plugin is not that small :) 

I believe the plugin may be improved. Please take a look at several enhancements in the plugin description, and let me know what you think. I am planning to work on them but would prefer to implement them separately after the first version of the plugin is integrated.