### PR TITLE
[WIP] Trying to fix issue #8691 - Find hidden gateway payment confirmation page 

### DIFF
--- a/w3af/plugins/crawl/payment_webhook_finder.py
+++ b/w3af/plugins/crawl/payment_webhook_finder.py
@@ -1,5 +1,5 @@
 """
-url_payment_finder.py
+payment_webhook_finder.py
 
 Copyright 2006 Andres Riancho
 
@@ -32,9 +32,9 @@ from w3af.core.data.kb.info import Info
 from w3af.core.data.request.fuzzable_request import FuzzableRequest
 
 
-class url_payment_finder(CrawlPlugin):
+class payment_webhook_finder(CrawlPlugin):
     """
-    Try to find hidden gateway payment confirmation page.
+    Find hidden payment gateway webhooks.
     :author: Coiffey Pierre (pierre.coiffey@gmail.com)
     """
     _dirs = ('/', '/inc/', '/include/', '/include/pay/', '/includes/', '/includes/pay/', '/lib/',
@@ -55,9 +55,6 @@ class url_payment_finder(CrawlPlugin):
 
         CrawlPlugin.__init__(self)
 
-        self._headers = None
-        self._first_time = True
-        self._fuzz_images = False
         self._seen = ScalableBloomFilter()
 
     def crawl(self, fuzzable_request):
@@ -138,7 +135,7 @@ class url_payment_finder(CrawlPlugin):
                  as parameter.
 
         >>> from w3af.core.data.parsers.doc.url import URL
-        >>> u = url_payment_finder()
+        >>> u = payment_webhook_finder()
         >>> url = URL( 'http://www.w3af.com/' )
         >>> list(u._mutate_path(url))
         []
@@ -182,9 +179,6 @@ class url_payment_finder(CrawlPlugin):
             self._head = True
         else:
             self._head = False
-
-    def _head_enabled(self):
-        return self._head
 
     def get_plugin_deps(self):
         """

--- a/w3af/plugins/crawl/url_payment_finder.py
+++ b/w3af/plugins/crawl/url_payment_finder.py
@@ -1,5 +1,5 @@
 """
-url_payment_fuzzer.py
+url_payment_finder.py
 
 Copyright 2006 Andres Riancho
 

--- a/w3af/plugins/crawl/url_payment_finder.py
+++ b/w3af/plugins/crawl/url_payment_finder.py
@@ -1,0 +1,218 @@
+"""
+url_payment_fuzzer.py
+
+Copyright 2006 Andres Riancho
+
+This file is part of w3af, http://w3af.org/ .
+
+w3af is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation version 2 of the License.
+
+w3af is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with w3af; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+"""
+from itertools import chain, repeat, izip
+
+import w3af.core.controllers.output_manager as om
+import w3af.core.data.kb.knowledge_base as kb
+from w3af.core.controllers.plugins.crawl_plugin import CrawlPlugin
+from w3af.core.controllers.core_helpers.fingerprint_404 import is_404
+from w3af.core.data.dc.headers import Headers
+from w3af.core.data.bloomfilter.scalable_bloom import ScalableBloomFilter
+from w3af.core.data.parsers.doc.url import URL
+from w3af.core.data.kb.info import Info
+from w3af.core.data.request.fuzzable_request import FuzzableRequest
+
+
+class url_payment_fuzzer(CrawlPlugin):
+    """
+    Try to find hidden gateway payment confirmation page.
+    :author: Coiffey Pierre (pierre.coiffey@gmail.com)
+    """
+    _dirs = ('/', '/inc/', '/include/', '/include/pay/', '/includes/', '/includes/pay/', '/lib/',
+             '/libraries/', '/module/', '/module/pay/', '/modules/', '/modules/pay/', '/payment/',
+             '/shop/', '/store/', '/svc/', '/servlet/', '/cgi/', '/cgi-bin/', '/cgibin/',
+    )
+
+    _files = ('pay', 'payment', 'success', 'paymentsuccess', 'paymentcomplete', 'paymentsuccessful',
+              'successful', 'paid', 'return', 'valid', 'validpay', 'validate', 'validatepayment',
+              'validatepay', 'validation', 'complete', 'completepay', 'completepayment',
+              'trxcomplete', 'transactioncomplete', 'final', 'finished',
+    )
+    _exts = ('', '.php', '.asp', '.aspx', '.jsp', '.py', 
+             '.pl', '.rb', '.cgi', '.php3',  '.php4', '.php5',
+    )
+
+    def __init__(self):
+
+        CrawlPlugin.__init__(self)
+
+        self._headers = None
+        self._first_time = True
+        self._fuzz_images = False
+        self._seen = ScalableBloomFilter()
+
+    def crawl(self, fuzzable_request):
+        """
+        Searches for new Url's using fuzzing.
+
+        :param fuzzable_request: A fuzzable_request instance that contains
+                                    (among other things) the URL to test.
+        """
+        url = fuzzable_request.get_url()
+        self._headers = Headers([('Referer', url.url_string)])
+
+        if self._first_time:
+            self._verify_head_enabled(url)
+            self._first_time = False
+
+        # First we need to delete fragments and query strings from URL.
+        url = url.uri2url()
+
+        # And we mark this one as a "do not return" URL, because the
+        # core already found it using another technique.
+        self._seen.add(url)
+
+        self._verify_head_enabled(url)
+
+        if self._head_enabled():
+            response = self._uri_opener.HEAD(url, cache=True,
+                                             headers=self._headers)
+        else:
+            response = self._uri_opener.GET(url, cache=True,
+                                            headers=self._headers)
+
+        if response.is_text_or_html():
+            mutants_chain = chain(self._mutate_path(url))
+
+            url_repeater = repeat(url)
+            args = izip(url_repeater, mutants_chain)
+
+            self.worker_pool.map_multi_args(self._do_request, args)
+
+    def _do_request(self, url, mutant):
+        """
+        Perform a simple GET to see if the result is an error or not, and then
+        run the actual fuzzing.
+        """
+        response = self._uri_opener.GET(mutant, cache=True,
+                                        headers=self._headers)
+
+        if (response.get_code() in (403, 401) or not(is_404(response))):
+
+            # Create the fuzzable request and send it to the core
+            fr = FuzzableRequest.from_http_response(response)
+            self.output_queue.put(fr)
+            
+            #
+            #   Save it to the kb (if new)!
+            #
+            if response.get_url() not in self._seen and response.get_url().get_file_name():
+                desc = 'A potentially interesting url was found : "%s".'
+                desc = desc % response.get_url()
+
+                i = Info('Potentially interesting url', desc, response.id,
+                         self.get_name())
+                i.set_url(response.get_url())
+                
+                kb.kb.append(self, 'url', i)
+                om.out.information(i.get_desc())
+
+                # Report only once
+                self._seen.add(response.get_url())
+
+    def _mutate_path(self, url):
+        """
+        Mutate the path of the url.
+
+        :param url: A URL to transform.
+        :return: A list of URL's that mutate the original url passed
+                 as parameter.
+
+        >>> from w3af.core.data.parsers.doc.url import URL
+        >>> u = url_payment_fuzzer()
+        >>> url = URL( 'http://www.w3af.com/' )
+        >>> list(u._mutate_path(url))
+        []
+
+        >>> URL('http://www.w3af.com/inc/payment.php') in mutants
+        True
+        >>> URL('http://www.w3af.com//module/pay/valid.aspx') in mutants
+        True
+        >>> URL('http://www.w3af.com/cgi-bin/paymentsuccessful.cgi') in mutants
+        True
+        """
+        url_string = url.url_string
+
+        if url_string.count('/') > 2:
+            # Create the new path
+            url_string = url_string[:url_string.rfind('/')]
+
+            dir_to_append_list = self._dirs
+            file_to_append_list = self._files
+            ext_to_append_list = self._exts
+            
+            for dir_to_append in dir_to_append_list:
+                for file_to_append in file_to_append_list:
+                    for ext_to_append in ext_to_append_list:
+                        newurl = URL(url_string + dir_to_append + file_to_append + ext_to_append)
+                        yield newurl
+
+    def _verify_head_enabled(self, url):
+        """
+        Verifies if the requested URL permits a HEAD request.
+        This was saved inside the KB by the plugin allowed_methods
+
+        :return : Sets self._head to the correct value, nothing is returned.
+        """
+        allowed_methods_infos = kb.kb.get('allowed_methods', 'methods')
+        allowed_methods = []
+        for info in allowed_methods_infos:
+            allowed_methods.extend(info['methods'])
+        
+        if 'HEAD' in allowed_methods:
+            self._head = True
+        else:
+            self._head = False
+
+    def _head_enabled(self):
+        return self._head
+
+    def get_plugin_deps(self):
+        """
+        :return: A list with the names of the plugins that should be run before the
+        current one.
+        """
+        return ['infrastructure.allowed_methods']
+
+    def get_long_desc(self):
+        """
+        :return: A DETAILED description of the plugin functions and features.
+        """
+        return """
+        This plugin will try to find new URL's based on the input. If the input
+        is for example:
+            - http://host.tld
+
+        The plugin will request:
+            - http://host.tld/include/pay/success.php
+            - http://host.tld/cgi/validate/payment.cgi
+            ...
+            - http://host.tld/modules/pay/paid.py
+
+        If the response is different from the 404 page (whatever it may be,
+        automatic detection is performed), then we have found a new URL. 
+        
+        Useful if you're pentesting a payement gateway that uses a hidden 
+        payment confirmation page which is accessed by the payment
+        gateway and not intended for public access.
+
+        """

--- a/w3af/plugins/crawl/url_payment_finder.py
+++ b/w3af/plugins/crawl/url_payment_finder.py
@@ -32,7 +32,7 @@ from w3af.core.data.kb.info import Info
 from w3af.core.data.request.fuzzable_request import FuzzableRequest
 
 
-class url_payment_fuzzer(CrawlPlugin):
+class url_payment_finder(CrawlPlugin):
     """
     Try to find hidden gateway payment confirmation page.
     :author: Coiffey Pierre (pierre.coiffey@gmail.com)
@@ -138,7 +138,7 @@ class url_payment_fuzzer(CrawlPlugin):
                  as parameter.
 
         >>> from w3af.core.data.parsers.doc.url import URL
-        >>> u = url_payment_fuzzer()
+        >>> u = url_payment_finder()
         >>> url = URL( 'http://www.w3af.com/' )
         >>> list(u._mutate_path(url))
         []

--- a/w3af/plugins/crawl/url_payment_finder.py
+++ b/w3af/plugins/crawl/url_payment_finder.py
@@ -203,6 +203,7 @@ class url_payment_finder(CrawlPlugin):
             - http://host.tld
 
         The plugin will request:
+            - http://host.tld/inc/
             - http://host.tld/include/pay/success.php
             - http://host.tld/cgi/validate/payment.cgi
             ...


### PR DESCRIPTION
This work is in progress.

I started by taking the url_fuzzer.py as an example.
I looked at the Nikto db at https://raw.github.com/sullo/nikto/master/program/databases/db_tests and
https://raw.githubusercontent.com/andresriancho/w3af/master/w3af/plugins/crawl/pykto/scan_database.db

It seems that there are some directories and files in common but most of them doesn't appear in the nikto db (assuming I looked at the right ones). Here are the common elements : 

Directories :  
/inc/
/include/
/includes/
/lib/
/module/
/modules/
/shop/
/store/
/servlet/
/cgi/
/cgi-bin/
/cgibin/

Files :
payment
payments

I tested my plugin with the python SimpleHTTPServer, I created directories and files corresponding to the one my plugin is generating.
w3af was able to find the directories and files created.

This is my first contribution I'm eager to ear some advices or directions I should continue toward in order to merge this plugin.

I hope I explained myself well enough. 