### PR TITLE
Implement bfac tricks into url_fuzzer

### DIFF
--- a/w3af/plugins/crawl/url_fuzzer.py
+++ b/w3af/plugins/crawl/url_fuzzer.py
@@ -53,6 +53,9 @@ class url_fuzzer(CrawlPlugin):
                     '.sql.gz', '.bak.sql', '.bak.sql.gz', '.bak.sql.bz2',
                     '.bak.sql.tar.gz'
                    )
+    _prependables = ('_', '.', '~', '.~', 'Copy_', 'Copy_of_', 'Copy_(1)_of_',
+                     'Copy_(2)_of_', 'Copy ', 'Copy of ', 'backup-'
+                    )
     _backup_exts = ('tar.gz', '7z', 'gz', 'cab', 'tgz', 'gzip',
                     'bzip2', 'zip', 'rar'
                     )

--- a/w3af/plugins/crawl/url_fuzzer.py
+++ b/w3af/plugins/crawl/url_fuzzer.py
@@ -311,6 +311,33 @@ class url_fuzzer(CrawlPlugin):
                 url_copy.set_extension(filetype)
                 yield url_copy
 
+    def _mutate_file_name(self, url):
+        filename = url.get_file_name()
+        if filename:
+            domain = url.get_domain_path()
+            url_string = domain.url_string
+            name = filename[:filename.rfind(u'.')]
+            extension = url.get_extension()
+
+            mutate_name_testing = (
+                url_string + '#' + filename + '#',
+                url_string + name + ' (copy).' + extension,
+                url_string + name + ' - Copy.' + extension,
+                url_string + name + ' copy.' + extension,
+                url_string + '.~lock.' + filename + '#',
+                url_string + name + '-backup.' + extension,
+                url_string + name + '-bkp.' + extension,
+                url_string + '.' + name + '.swp',
+                url_string + '_' + name + '.swp',
+                url_string + '.' + name + '.swo',
+                url_string + '_' + name + '.swo',
+                url_string + '~' + name + '.tmp'
+            )
+
+            for change in mutate_name_testing:
+                newurl = URL(change)
+                yield newurl
+
     def _mutate_path(self, url):
         """
         Mutate the path instead of the file.

--- a/w3af/plugins/crawl/url_fuzzer.py
+++ b/w3af/plugins/crawl/url_fuzzer.py
@@ -319,17 +319,22 @@ class url_fuzzer(CrawlPlugin):
         if filename:
             domain = url.get_domain_path()
             url_string = domain.url_string
-            name = filename[:filename.rfind(u'.')]
             extension = url.get_extension()
+
+            if extension:
+                extension = '.' + extension
+                name = filename[:filename.rfind(u'.')]
+            else:
+                name = filename
 
             mutate_name_testing = {
                 url_string + '#' + filename + '#',
-                url_string + name + ' (copy).' + extension,
-                url_string + name + ' - Copy.' + extension,
-                url_string + name + ' copy.' + extension,
+                url_string + name + ' (copy)' + extension,
+                url_string + name + ' - Copy' + extension,
+                url_string + name + ' copy' + extension,
                 url_string + '.~lock.' + filename + '#',
-                url_string + name + '-backup.' + extension,
-                url_string + name + '-bkp.' + extension,
+                url_string + name + '-backup' + extension,
+                url_string + name + '-bkp' + extension,
                 url_string + '.' + filename + '.swp',
                 url_string + '_' + filename + '.swp',
                 url_string + '.' + filename + '.swo',

--- a/w3af/plugins/crawl/url_fuzzer.py
+++ b/w3af/plugins/crawl/url_fuzzer.py
@@ -57,8 +57,8 @@ class url_fuzzer(CrawlPlugin):
                      'Copy_(2)_of_', 'Copy ', 'Copy of ', 'backup-'
                     )
     _backup_exts = ('tar.gz', '7z', 'gz', 'cab', 'tgz', 'gzip',
-                    'bzip2', 'zip', 'rar'
-                    )
+                    'bzip2', 'zip', 'rar', 'tar'
+                   )
     _file_types = (
         'inc', 'fla', 'jar', 'war', 'java', 'class', 'properties',
         'bak', 'bak1', 'backup', 'backup1', 'old', 'old1', 'c', 'cpp',

--- a/w3af/plugins/crawl/url_fuzzer.py
+++ b/w3af/plugins/crawl/url_fuzzer.py
@@ -343,8 +343,12 @@ class url_fuzzer(CrawlPlugin):
             }
 
             for change in mutate_name_testing:
-                newurl = URL(change)
-                yield newurl
+                try :
+                    newurl = URL(change)
+                    yield newurl
+                except ValueError as exception:
+                    om.out.information('Error while generating a new URL: '\
+                    + exception)
 
     def _mutate_path(self, url):
         """

--- a/w3af/plugins/crawl/url_fuzzer.py
+++ b/w3af/plugins/crawl/url_fuzzer.py
@@ -248,6 +248,37 @@ class url_fuzzer(CrawlPlugin):
                 url_copy.set_file_name(filename)
                 yield url_copy
 
+    def _mutate_by_prepending(self, url):
+        """
+        Adds something before the file name of the url (mutate the file being requested)
+
+        :param url: A URL to transform.
+        :return: A list of URL's that mutate the original url passed
+                 as parameter.
+
+        >>> from w3af.core.data.parsers.doc.url import URL
+        >>> u = url_fuzzer()
+        >>> url = URL( 'http://www.w3af.com/' )
+        >>> mutants = u._mutate_by_prepending( url )
+        >>> list(mutants)
+        []
+
+        >>> url = URL( 'http://www.w3af.com/foo.html' )
+        >>> mutants = u._mutate_by_prepending( url )
+        >>> URL( 'http://www.w3af.com/.foo.html' ) in mutants
+        True
+        >>> URL( 'http://www.w3af.com/Copy_of_foo.html' ) in mutants
+        True
+
+        """
+        if not url.url_string.endswith('/') and url.url_string.count('/') >= 3:
+            for to_prepend in self._prependables:
+                url_copy = url.copy()
+                filename = url_copy.get_file_name()
+                filename = to_prepend + filename
+                url_copy.set_file_name(filename)
+                yield url_copy
+
     def _mutate_file_type(self, url):
         """
         If the url is : "http://www.foobar.com/asd.txt" this method returns:

--- a/w3af/plugins/crawl/url_fuzzer.py
+++ b/w3af/plugins/crawl/url_fuzzer.py
@@ -107,7 +107,10 @@ class url_fuzzer(CrawlPlugin):
             mutants_chain = chain(self._mutate_by_appending(url),
                                   self._mutate_path(url),
                                   self._mutate_file_type(url),
-                                  self._mutate_domain_name(url))
+                                  self._mutate_domain_name(url),
+                                  self._mutate_by_prepending(url),
+                                  self._mutate_file_name(url)
+                                  )
             url_repeater = repeat(url)
             args = izip(url_repeater, mutants_chain)
 

--- a/w3af/plugins/crawl/url_fuzzer.py
+++ b/w3af/plugins/crawl/url_fuzzer.py
@@ -49,11 +49,11 @@ class url_fuzzer(CrawlPlugin):
                     '.$$$', '.sav', '.save', '.saved', '.swp', '.swo',
                     '.copy', '.original', '.orig', '.org', '.txt', '.default',
                     '.tpl', '.tmp', '.temp', '.conf', '.nsx', '.cs', '.csproj',
-                    '.vb', '.0', '.1', '.2', '.arc', '.lst', '.inc', '::$DATA',
+                    '.vb', '.0', '.1', '.2', '.arc', '.lst', '::$DATA',
                     '.sql.gz', '.bak.sql', '.bak.sql.gz', '.bak.sql.bz2',
                     '.bak.sql.tar.gz'
                    )
-    _prependables = ('_', '.', '~', '.~', 'Copy_', 'Copy_of_', 'Copy_(1)_of_',
+    _prependables = ('_', '.', '~', '.~', '.$', 'Copy_', 'Copy_of_', 'Copy_(1)_of_',
                      'Copy_(2)_of_', 'Copy ', 'Copy of ', 'backup-'
                     )
     _backup_exts = ('tar.gz', '7z', 'gz', 'cab', 'tgz', 'gzip',

--- a/w3af/plugins/crawl/url_fuzzer.py
+++ b/w3af/plugins/crawl/url_fuzzer.py
@@ -41,11 +41,18 @@ class url_fuzzer(CrawlPlugin):
     Try to find backups, and other related files.
     :author: Andres Riancho (andres.riancho@gmail.com)
     """
-    _appendables = ('~', '.tar.gz', '.gz', '.7z', '.cab', '.tgz',
-                    '.gzip', '.bzip2', '.inc', '.zip', '.rar', '.jar', '.java',
-                    '.class', '.properties', '.bak', '.bak1', '.bkp', '.back',
-                    '.backup', '.backup1', '.old', '.old1', '.$$$'
-                    )
+    _appendables = ('~', '~~', '_', '.', '.tar.gz', '.gz', '.7z', '.cab',
+                    '.tgz', '.gzip', '.bzip2', '.inc', '.zip', '.rar',
+                    '.tar', '.jar', '.java', '.class', '.properties',
+                    '.bak', '.bak1', '_bak', '-bak', '.bk', '.bkp', '.back',
+                    '.bac', '.backup', '.backup1', '.old', '.old1', '_old',
+                    '.$$$', '.sav', '.save', '.saved', '.swp', '.swo',
+                    '.copy', '.original', '.orig', '.org', '.txt', '.default',
+                    '.tpl', '.tmp', '.temp', '.conf', '.nsx', '.cs', '.csproj',
+                    '.vb', '.0', '.1', '.2', '.arc', '.lst', '.inc', '::$DATA',
+                    '.sql.gz', '.bak.sql', '.bak.sql.gz', '.bak.sql.bz2',
+                    '.bak.sql.tar.gz'
+                   )
     _backup_exts = ('tar.gz', '7z', 'gz', 'cab', 'tgz', 'gzip',
                     'bzip2', 'zip', 'rar'
                     )

--- a/w3af/plugins/crawl/url_fuzzer.py
+++ b/w3af/plugins/crawl/url_fuzzer.py
@@ -59,11 +59,12 @@ class url_fuzzer(CrawlPlugin):
     _backup_exts = ('tar.gz', '7z', 'gz', 'cab', 'tgz', 'gzip',
                     'bzip2', 'zip', 'rar', 'tar'
                    )
-    _file_types = (
-        'inc', 'fla', 'jar', 'war', 'java', 'class', 'properties',
-        'bak', 'bak1', 'backup', 'backup1', 'old', 'old1', 'c', 'cpp',
-        'cs', 'vb', 'phps', 'disco', 'ori', 'orig', 'original'
-    )
+    _file_types = ('inc', 'fla', 'jar', 'war', 'java', 'class', 'properties',
+                   'bak', 'bak1', 'backup', 'backup1', 'old', 'old1', 'c', 'cpp',
+                   'cs', 'vb', 'phps', 'disco', 'ori', 'orig', 'original', 'save',
+                   'saved', 'bkp', 'txt', 'tpl', 'tmp', 'temp', 'bakup', 'bakup1',
+                   'sql'
+                  )
 
     def __init__(self):
         CrawlPlugin.__init__(self)

--- a/w3af/plugins/crawl/url_fuzzer.py
+++ b/w3af/plugins/crawl/url_fuzzer.py
@@ -330,11 +330,11 @@ class url_fuzzer(CrawlPlugin):
                 url_string + '.~lock.' + filename + '#',
                 url_string + name + '-backup.' + extension,
                 url_string + name + '-bkp.' + extension,
-                url_string + '.' + name + '.swp',
-                url_string + '_' + name + '.swp',
-                url_string + '.' + name + '.swo',
-                url_string + '_' + name + '.swo',
-                url_string + '~' + name + '.tmp'
+                url_string + '.' + filename + '.swp',
+                url_string + '_' + filename + '.swp',
+                url_string + '.' + filename + '.swo',
+                url_string + '_' + filename + '.swo',
+                url_string + '~' + filename + '.tmp'
             )
 
             for change in mutate_name_testing:

--- a/w3af/plugins/crawl/url_fuzzer.py
+++ b/w3af/plugins/crawl/url_fuzzer.py
@@ -41,7 +41,7 @@ class url_fuzzer(CrawlPlugin):
     Try to find backups, and other related files.
     :author: Andres Riancho (andres.riancho@gmail.com)
     """
-    _appendables = ('~', '~~', '_', '.', '.tar.gz', '.gz', '.7z', '.cab',
+    _appendables = {'~', '~~', '_', '.', '.tar.gz', '.gz', '.7z', '.cab',
                     '.tgz', '.gzip', '.bzip2', '.inc', '.zip', '.rar',
                     '.tar', '.jar', '.java', '.class', '.properties',
                     '.bak', '.bak1', '_bak', '-bak', '.bk', '.bkp', '.back',
@@ -52,19 +52,19 @@ class url_fuzzer(CrawlPlugin):
                     '.vb', '.0', '.1', '.2', '.arc', '.lst', '::$DATA',
                     '.sql.gz', '.bak.sql', '.bak.sql.gz', '.bak.sql.bz2',
                     '.bak.sql.tar.gz'
-                   )
-    _prependables = ('_', '.', '~', '.~', '.$', 'Copy_', 'Copy_of_', 'Copy_(1)_of_',
+                    }
+    _prependables = {'_', '.', '~', '.~', '.$', 'Copy_', 'Copy_of_', 'Copy_(1)_of_',
                      'Copy_(2)_of_', 'Copy ', 'Copy of ', 'backup-'
-                    )
-    _backup_exts = ('tar.gz', '7z', 'gz', 'cab', 'tgz', 'gzip',
+                    }
+    _backup_exts = {'tar.gz', '7z', 'gz', 'cab', 'tgz', 'gzip',
                     'bzip2', 'zip', 'rar', 'tar'
-                   )
-    _file_types = ('inc', 'fla', 'jar', 'war', 'java', 'class', 'properties',
+                   }
+    _file_types = {'inc', 'fla', 'jar', 'war', 'java', 'class', 'properties',
                    'bak', 'bak1', 'backup', 'backup1', 'old', 'old1', 'c', 'cpp',
                    'cs', 'vb', 'phps', 'disco', 'ori', 'orig', 'original', 'save',
                    'saved', 'bkp', 'txt', 'tpl', 'tmp', 'temp', 'bakup', 'bakup1',
                    'sql'
-                  )
+                  }
 
     def __init__(self):
         CrawlPlugin.__init__(self)
@@ -322,7 +322,7 @@ class url_fuzzer(CrawlPlugin):
             name = filename[:filename.rfind(u'.')]
             extension = url.get_extension()
 
-            mutate_name_testing = (
+            mutate_name_testing = {
                 url_string + '#' + filename + '#',
                 url_string + name + ' (copy).' + extension,
                 url_string + name + ' - Copy.' + extension,
@@ -335,7 +335,7 @@ class url_fuzzer(CrawlPlugin):
                 url_string + '.' + filename + '.swo',
                 url_string + '_' + filename + '.swo',
                 url_string + '~' + filename + '.tmp'
-            )
+            }
 
             for change in mutate_name_testing:
                 newurl = URL(change)


### PR DESCRIPTION
See #16271 

Hey, here is a first try.

What I added:
- new `appendables`, `backup_exts` and `file_types`
- new set of prependables (like `Copy_of_`)
- a function `_mutate_by_prepending` to generate new URLs from this set
- a function `_mutate_file_name` to generate change on the name of the file like : `index.html` -> `index-backup.html`, `index (copy).html`, `.index.html.swp`, etc
- and ofc the calls to the new functions

I checked that new patterns don't create duplicates of existing URLs.
I don't know if the function `_mutate_file_name` is the best way to do it. I used the same technique as `bfac`, what do you think about this function ?

I performed some tests, everything works properly but I found something strange. The plugin finds all 26 URLs it could find on the server but the list of fuzzable requests contains several times `http://localhost/`.
See the attached file [output.txt](https://github.com/andresriancho/w3af/files/2609461/output.txt) for the list of file on the test server and w3af output.


This bug as something to do with the new function `_mutate_file_name`. It found 6 new URLs and there's 6 more `http://localhost/` in the fuzzable requests. If the plugin don't call the function the result is good. I'm sure that the function doesn't create this URL directly. I'll work on it.