### PR TITLE
Separated double-purposed self._expressions variable, now it simply h…

### DIFF
--- a/w3af/plugins/mangle/sed.py
+++ b/w3af/plugins/mangle/sed.py
@@ -117,14 +117,14 @@ class sed(ManglePlugin):
         self._user_option_fix_content_len = option_list['fix_content_len'].get_value()
 
         self._expressions = ','.join(option_list['expressions'].get_value())
-        self._expressions = re.findall('([qs])([bh])/(.*?)/(.*?)/;?',
+        found_expressions = re.findall('([qs])([bh])/(.*?)/(.*?)/;?',
                                        self._expressions)
 
-        if len(self._expressions) == 0 and len(option_list['expressions'].get_value()) != 0:
+        if len(found_expressions) == 0 and len(option_list['expressions'].get_value()) != 0:
             msg = 'The user specified expression is invalid.'
             raise BaseFrameworkException(msg)
 
-        for exp in self._expressions:
+        for exp in found_expressions:
             req_res, body_header, regex_str, target_str = exp
             
             if req_res not in ('q', 's'):


### PR DESCRIPTION
Separated double-purposed self._expressions variable, now it simply holds the comma-separated expression strings while found_expressions within the set_options() scope holds the list of match tuples parsed be re.  Fix for issue #17672.