### PR TITLE
Better support for path parameters in OpenAPI plugin

### DIFF
--- a/w3af/core/data/fuzzer/mutants/tests/test_urlparts_mutant.py
+++ b/w3af/core/data/fuzzer/mutants/tests/test_urlparts_mutant.py
@@ -129,3 +129,22 @@ class TestURLPartsMutant(unittest.TestCase):
         generated_urls = set([m.get_url().url_string for m in generated_mutants])
 
         self.assertEqual(set(expected_urls), generated_urls)
+
+    def test_forced_url_parts(self):
+        freq = FuzzableRequest(URL('http://www.w3af.com/static/foo/bar.ext'))
+        freq.set_force_fuzzing_url_parts([
+            ('/static/', False), ('foo', True), ('/bar.', False), ('ext', True)
+        ])
+
+        generated_mutants = URLPartsMutant.create_mutants(
+            freq, self.payloads, [],
+            False, self.fuzzer_config)
+
+        expected_urls = ['http://www.w3af.com/static/abc/bar.ext',
+                         'http://www.w3af.com/static/def/bar.ext',
+                         'http://www.w3af.com/static/foo/bar.abc',
+                         'http://www.w3af.com/static/foo/bar.def']
+
+        generated_urls = set([m.get_url().url_string for m in generated_mutants])
+
+        self.assertEqual(set(expected_urls), generated_urls)

--- a/w3af/core/data/fuzzer/mutants/tests/test_urlparts_mutant.py
+++ b/w3af/core/data/fuzzer/mutants/tests/test_urlparts_mutant.py
@@ -148,3 +148,22 @@ class TestURLPartsMutant(unittest.TestCase):
         generated_urls = set([m.get_url().url_string for m in generated_mutants])
 
         self.assertEqual(set(expected_urls), generated_urls)
+
+    def test_forced_url_parts_qs(self):
+        freq = FuzzableRequest(URL('http://www.w3af.com/static/foo/bar.ext?foo=bar'))
+        freq.set_force_fuzzing_url_parts([
+            ('/static/', False), ('foo', True), ('/bar.', False), ('ext', True)
+        ])
+
+        generated_mutants = URLPartsMutant.create_mutants(
+            freq, self.payloads, [],
+            False, self.fuzzer_config)
+
+        expected_uris = ['http://www.w3af.com/static/abc/bar.ext?foo=bar',
+                         'http://www.w3af.com/static/def/bar.ext?foo=bar',
+                         'http://www.w3af.com/static/foo/bar.abc?foo=bar',
+                         'http://www.w3af.com/static/foo/bar.def?foo=bar']
+
+        generated_uris = set([m.get_uri().url_string for m in generated_mutants])
+
+        self.assertEqual(set(expected_uris), generated_uris)

--- a/w3af/core/data/fuzzer/mutants/urlparts_mutant.py
+++ b/w3af/core/data/fuzzer/mutants/urlparts_mutant.py
@@ -95,7 +95,23 @@ class URLPartsMutant(Mutant):
                                          self._url_parts_dc.url_end))
         return domain_path
 
-    get_uri = get_url
+    def get_uri(self):
+        """
+        :return: The URI, as modified by "set_token_value()"
+        """
+        # Please note that this double encoding is needed if we want to work
+        # with mod_rewrite
+        encoded = urllib.quote_plus(self._url_parts_dc[TOKEN].get_value(),
+                                    self._safe_encode_chars)
+        if self._double_encoding:
+            encoded = urllib.quote_plus(encoded, safe=self._safe_encode_chars)
+
+        path = '%s%s%s' % (self._url_parts_dc.url_start,
+                           encoded,
+                           self._url_parts_dc.url_end)
+        modified_uri = self._freq.get_uri().copy()
+        modified_uri.path = path
+        return modified_uri
 
     def set_url(self, u):
         msg = "You can't change the value of the URL in a URLPartsMutant"\

--- a/w3af/core/data/parsers/doc/open_api/main.py
+++ b/w3af/core/data/parsers/doc/open_api/main.py
@@ -62,11 +62,13 @@ class OpenAPI(BaseParser):
                 'swagger',
                 'paths')
 
-    def __init__(self, http_response, no_validation=False, discover_fuzzable_headers=True):
+    def __init__(self, http_response, no_validation=False, discover_fuzzable_headers=True,
+                 discover_fuzzable_url_parts=True):
         super(OpenAPI, self).__init__(http_response)
         self.api_calls = []
         self.no_validation = no_validation
         self.discover_fuzzable_headers = discover_fuzzable_headers
+        self.discover_fuzzable_url_parts = discover_fuzzable_url_parts
 
     @staticmethod
     def content_type_match(http_resp):
@@ -149,7 +151,8 @@ class OpenAPI(BaseParser):
         for data in specification_handler.get_api_information():
             try:
                 request_factory = RequestFactory(*data)
-                fuzzable_request = request_factory.get_fuzzable_request(self.discover_fuzzable_headers)
+                fuzzable_request = request_factory.get_fuzzable_request(self.discover_fuzzable_headers,
+                                                                        self.discover_fuzzable_url_parts)
             except Exception, e:
                 #
                 # This is a strange situation because parsing of the OpenAPI

--- a/w3af/core/data/parsers/doc/open_api/requests.py
+++ b/w3af/core/data/parsers/doc/open_api/requests.py
@@ -20,6 +20,8 @@ along with w3af; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 """
+import re
+
 from w3af.core.data.dc.headers import Headers
 from w3af.core.data.dc.query_string import QueryString
 from w3af.core.data.dc.json_container import JSONContainer
@@ -56,13 +58,17 @@ class RequestFactory(object):
         self.operation = operation
         self.parameters = parameters
 
-    def get_fuzzable_request(self, discover_fuzzable_headers=False):
+    def get_fuzzable_request(self, discover_fuzzable_headers=False,
+                             discover_fuzzable_url_parts=False):
         """
         Creates a fuzzable request by querying different parts of the spec
         parameters, operation, etc.
 
         :param discover_fuzzable_headers: If it's set to true,
                                           then all fuzzable headers will be added to the fuzzable request.
+        :param discover_fuzzable_url_parts: If it's set to true,
+                                            then all fuzzable url parts will be added to the fuzzable request.
+
         :return: A fuzzable request.
         """
         method = self.get_method()
@@ -77,6 +83,9 @@ class RequestFactory(object):
 
         if discover_fuzzable_headers:
             fuzzable_request.set_force_fuzzing_headers(self._get_parameter_headers())
+
+        if discover_fuzzable_url_parts:
+            fuzzable_request.set_force_fuzzing_url_parts(self._get_url_parts())
 
         return fuzzable_request
 
@@ -95,6 +104,24 @@ class RequestFactory(object):
                              % (self.operation.path_name, parameter.name))
 
         return list(parameter_headers)
+
+    def _get_url_parts(self):
+        """
+        Builds a forced url parts string based in 
+        """
+        path = self.operation.path_name
+        segments = re.split('({[^}]+})', path)
+        params = self._get_filled_parameters()
+        parts = []
+        for seg in segments:
+            if seg.startswith('{') and seg.endswith('}'):
+                name = seg[1:-1]
+                val = '{}'.format(params.get(name, seg))
+                parts.append((val, True))
+            else:
+                parts.append((seg, False))
+        return parts
+
 
     def _bravado_construct_request(self):
         """

--- a/w3af/core/data/request/fuzzable_request.py
+++ b/w3af/core/data/request/fuzzable_request.py
@@ -83,7 +83,8 @@ class FuzzableRequest(RequestMixIn, DiskItem):
                  '_uri',
                  '_url',
                  '_sent_info_comp',
-                 '_force_fuzzing_headers')
+                 '_force_fuzzing_headers',
+                 '_force_fuzzing_url_parts')
 
     def __init__(self, uri, method='GET', headers=None, cookie=None,
                  post_data=None):
@@ -117,6 +118,9 @@ class FuzzableRequest(RequestMixIn, DiskItem):
 
         # Set the headers which we want to fuzz explicitly (empty by default)
         self._force_fuzzing_headers = set()
+
+        # Set a path template explicitly (empty by default)
+        self._force_fuzzing_url_parts = tuple()
 
     def __getstate__(self):
         state = {k: getattr(self, k) for k in self.__slots__}
@@ -453,6 +457,26 @@ class FuzzableRequest(RequestMixIn, DiskItem):
         :return: A list of header names.
         """
         return list(self._force_fuzzing_headers)
+
+    def set_force_fuzzing_url_parts(self, url_parts):
+        """
+        Sets a list of url parts which should be fuzzed.
+        :param url_parts: An iterable of (path part, is variable) tuples.
+        """
+        if url_parts is None:
+            raise TypeError('url_parts should not be null')
+
+        if not isinstance(url_parts, collections.Iterable):
+            raise TypeError(TYPE_ERROR % ('_force_fuzzing_url_parts', 'iterable'))
+
+        self._force_fuzzing_url_parts = tuple(url_parts)
+
+    def get_force_fuzzing_url_parts(self):
+        """
+        Returns a list of url parts which should be fuzzed.
+        :return: A tuple of (path part, is variable) tuples.`
+        """
+        return list(self._force_fuzzing_url_parts)
 
     def set_referer(self, referer):
         self._headers['Referer'] = str(referer)

--- a/w3af/plugins/crawl/open_api.py
+++ b/w3af/plugins/crawl/open_api.py
@@ -414,10 +414,16 @@ class open_api(CrawlPlugin):
         ol.add(o)
 
         d = 'Automatic path parameter discovery for further testing'
-        h = ('By default, URLs discovered by this plugin allow for injection at path parameter'
-             ' locations, ignoring the value of the`fuzz_url_parts` setting.'
-             ' Set this options to False if you would like to disable this feature, and use the'
-             ' default `fuzz_url_parts` setting.')
+        h = ('By default, URLs discovered by this plugin allow for allow other plugins'
+             ' to inject content into the path only at locations declared as path parameters'
+             ' in the Open API specification.'
+             ' For example, if the Open API specification declares an endpoint with the path'
+             ' `/store/product-{productID}`, only the `{productID}` part of the URL will be modified'
+             ' during fuzzing.'
+             ' Set this option to False if you would like to disable this feature, and instead'
+             ' fuzz all path segments.'
+             ' If this option is set to False, the plugin will automatically set `misc-settings.fuzz_url_parts`'
+             ' and `misc-settings.fuzz_url_filenames` to True')
         o = opt_factory('discover_fuzzable_url_parts', self._discover_fuzzable_url_parts, d, BOOL, help=h)
         ol.add(o)
 
@@ -469,9 +475,4 @@ class open_api(CrawlPlugin):
         During parsing an Open API specification, the plugin looks for parameters
         which are passed to endpoints via HTTP headers, and enables them for further testing.
         This behavior may be disabled by setting 'discover_fuzzable_headers' configuration parameter to False.
-
-        By default, URLs discovered by this plugin allow for injection at path parameter
-        locations, ignoring the value of the`fuzz_url_parts` setting.
-        Set this options to False if you would like to disable this feature, and use the
-        default `fuzz_url_parts` setting.
         """


### PR DESCRIPTION
Right now, the OpenAPI plugin just forces on url_parts fuzzing.  This has two disadvantages:
1.)  It's slow. Adding injections to non-parameterized parts of the routes is useless for many REST APIs
2.) It's incorrect. Path parameters don't have to use a full segment.  For example `/foo/bar/product-{param}`, the route won't be matched if there's no `product-` at the beginning of the last segment.

This PR adds a forced URL parts to fuzzable requests that indicate path segments where injection is possible. This allows the OpenAPI plugin to properly handle path parameters.