### PR TITLE
Fix a problem when using w3af on a case insensitive FS

### DIFF
--- a/w3af/plugins/infrastructure/halberd.py
+++ b/w3af/plugins/infrastructure/halberd.py
@@ -19,6 +19,8 @@ along with w3af; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 """
+from __future__ import absolute_import
+
 import os
 import tempfile
 


### PR DESCRIPTION
When running w3af on a case-insensitive file system, the Halberd plugin has a problem where it tries to import itself vs. the real Halberd package, because they differ only by case.

I think this will fix https://github.com/andresriancho/w3af/issues/17475