### PR TITLE
Fix errors reconfiguring open_api plugin

### DIFF
--- a/w3af/core/data/options/header_option.py
+++ b/w3af/core/data/options/header_option.py
@@ -40,6 +40,8 @@ class HeaderOption(BaseOption):
         self._value = self.validate(value)
 
     def validate(self, value):
+        if isinstance(value, Headers):
+            return value
         try:
             return Headers.from_string(value)
         except Exception:

--- a/w3af/core/data/options/query_string_option.py
+++ b/w3af/core/data/options/query_string_option.py
@@ -20,6 +20,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 """
 from w3af.core.controllers.exceptions import BaseFrameworkException
+from w3af.core.data.dc.query_string import QueryString
 from w3af.core.data.options.baseoption import BaseOption
 from w3af.core.data.options.option_types import QUERY_STRING
 from w3af.core.data.parsers.doc.url import parse_qs
@@ -40,6 +41,8 @@ class QueryStringOption(BaseOption):
         self._value = self.validate(value)
 
     def validate(self, value):
+        if isinstance(value, QueryString):
+            return value
         try:
             return parse_qs(value)
         except Exception:


### PR DESCRIPTION
When setting configurations for open_api plugin in a profile, or
setting them multiple times from console, an error happens the
second time.

This happens because `set_value` is called with a `Headers` or
`QueryString` instance.  Then, in `validate` this is parsed as a
string, and an exception occurs.
