### PR TITLE
Fix race condition

### DIFF
--- a/w3af/core/controllers/threads/tests/test_threadpool.py
+++ b/w3af/core/controllers/threads/tests/test_threadpool.py
@@ -134,10 +134,11 @@ class TestWorkerPool(unittest.TestCase):
         # Let the worker get the task
         time.sleep(0.3)
 
+        func_name, func_args = worker_pool._pool[0].worker.get_real_func_name_args()
         # Got it?
         self.assertFalse(worker_pool._pool[0].worker.is_idle())
-        self.assertEqual(worker_pool._pool[0].worker.get_real_func_name(), 'sleep')
-        self.assertEqual(worker_pool._pool[0].worker.args, args)
+        self.assertEqual(func_name, 'sleep')
+        self.assertEqual(func_args, args)
         self.assertEqual(worker_pool._pool[0].worker.kwargs, kwds)
         self.assertGreater(worker_pool._pool[0].worker.job, 1)
 

--- a/w3af/core/controllers/threads/threadpool.py
+++ b/w3af/core/controllers/threads/threadpool.py
@@ -203,7 +203,7 @@ class Worker(object):
     def is_idle(self):
         return self.func is None
 
-    def get_real_func_name(self):
+    def get_real_func_name_args(self):
         """
         Because of various levels of abstraction the function name is not always in
         self.func.__name__, this method "unwraps" the abstractions and shows us
@@ -211,30 +211,36 @@ class Worker(object):
 
         :return: The function name
         """
-        if self.func is None:
+
+        # self.func/self.args could change over the execution of this method, so take
+        # a copy here.
+        current_func = self.func
+        current_args = self.args
+
+        if current_func is mapstar:
+            current_func = current_args[0][0]
+            current_args = current_args[0][1:]
+
+        if current_func is apply_with_return_error:
+            current_func = current_args[0][0]
+            current_args = current_args[0][1:]
+
+        if isinstance(current_func, return_args):
+            return current_func.func_orig.__name__
+
+        if isinstance(current_func, one_to_many):
+            return current_func.func_orig.__name__
+
+        if current_func is None:
             return None
 
-        if self.func is mapstar:
-            self.func = self.args[0][0]
-            self.args = self.args[0][1:]
-
-        if self.func is apply_with_return_error:
-            self.func = self.args[0][0]
-            self.args = self.args[0][1:]
-
-        if isinstance(self.func, return_args):
-            return self.func.func_orig.__name__
-
-        if isinstance(self.func, one_to_many):
-            return self.func.func_orig.__name__
-
-        return self.func.__name__
+        return current_func.__name__, current_args
 
     def get_state(self):
-        func_name = self.get_real_func_name()
+        func_name, func_args = self.get_real_func_name_args()
 
         return {'func_name': func_name,
-                'args': self.args,
+                'args': func_args,
                 'kwargs': self.kwargs,
                 'start_time': self.start_time,
                 'idle': self.is_idle(),


### PR DESCRIPTION
Occasionally inspect_threads() would raise an exeception.

This was caused by self.func becoming None after the check at the
top of get_real_func_name since inspect_threads() is called on a
different thread than self.func is set on.

Refactor the code such that checking the state of a thread never
mutates self.func/self.args, and there is no time of check/time of
use mismatch that can lead to an exception.