### PR TITLE
Add a way to specify combinations of OpenAPI parameters to fuzz via extension field

### DIFF
--- a/w3af/core/data/parsers/doc/open_api/tests/data/templated.json
+++ b/w3af/core/data/parsers/doc/open_api/tests/data/templated.json
@@ -1,0 +1,103 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "Swagger API Team"
+    },
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/api",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "description": "Gets a pet by a criteria",
+        "operationId": "getPetBy",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "description": "name of pet",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "owner",
+            "in": "query",
+            "description": "owner of pet",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          }
+        },
+        "x-w3af-request-templates": [
+          {
+            "parameters": [
+              {
+                "name": "name",
+                "in": "query",
+                "description": "name of pet",
+                "required": true,
+                "type": "string",
+                "default": "Rover"
+              }
+            ]
+          },
+          {
+            "parameters": [
+              {
+                "name": "owner",
+                "in": "query",
+                "description": "owner of pet",
+                "required": true,
+                "type": "string",
+                "default": "John Smith"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/w3af/core/data/parsers/doc/open_api/tests/example_specifications.py
+++ b/w3af/core/data/parsers/doc/open_api/tests/example_specifications.py
@@ -79,6 +79,11 @@ class MultiplePathsAndHeaders(object):
         return file('%s/data/multiple_paths_and_headers.json' % CURRENT_PATH).read()
 
 
+class Templated(object):
+    def get_specification(self):
+        return file('%s/data/templated.json' % CURRENT_PATH).read()
+
+
 class PetstoreSimpleModel(object):
 
     @staticmethod

--- a/w3af/plugins/crawl/open_api.py
+++ b/w3af/plugins/crawl/open_api.py
@@ -458,4 +458,33 @@ class open_api(CrawlPlugin):
         During parsing an Open API specification, the plugin looks for parameters
         which are passed to endpoints via HTTP headers, and enables them for further testing.
         This behavior may be disabled by setting 'discover_fuzzable_headers' configuration parameter to False.
+
+        To allow for testing of complex REST APIs, this plugin supports an extension to the Open API
+        specification: If an extension field named `x-w3af-request-templates` exists on an operation,
+        this plugin will use the contents to create multiple requests for the operation, each configured
+        in a specific way. The `x-w3af-request-templates` field is structured as a list of dicts, each of
+        which contains overrides to the operation it appears on. For each item in the list, the plugin
+        will create a separate URL to test, configured according to the overrides in that item. For example,
+        the following fragment would produce two URLs for testing:
+
+        ...
+        "x-w3af-request-templates": [
+            {
+                "parameters": [
+                    {"name": "foo", "in": "query", "default": "value1"},
+                ]
+            },
+            {
+                "parameters": [
+                    {"name": "bar", "in": "query", "default": "value2"},
+                ]
+            }
+        ]
+        ...
+
+        If the original operation was http://www.w3af.org/api/test?foo=&bar=,
+        then this configuration would produce for testing the URLs
+        http://www.w3af.org/api/test?foo=value1
+        http://www.w3af.org/api/test?bar=value2
+
         """


### PR DESCRIPTION
I am not sure if this is the best way to go about this, but I'm opening this PR to see if you think this is a good idea. Basically, the problem I am trying to solve is that some REST APIs I am trying to test have certain combinations of parameters that are valid. This means that the current approach of filling in all the parameters that are discovered in each operation won't work, as the testing never gets past the validation phase.

My solution to this: add an extension field to the operation in the Open API spec, that if present will further refine the request that w3af creates. A good example is in the test case I added, but basically the extension parameter `x-w3af-request-templates` contains a list of overrides to the operation it is contained in. When this is encountered, each override is applied, and a separate fuzzable request is generated for each one.

As an example, say I have an API that is available at `http://www.example.com/products/search`. This API can take exactly one query string parameter from the set of `{name, description, price}` to search by the specified parameter. If you specify a search by multiple criteria a validation error will occur. Right now there's no way to teach w3af about this (or many other restrictions that are described in text but not expressible in swagger like dependencies between parameters, etc). With this change I can write something like:

```
<snip>
"/products/search": {
  "get": {
    "parameters": [
      <definition for name, required=false>,
      <definition for description, required=false>,
      <definition for price, required=false>
    ],
    "x-w3af-request-templates": [
      {"parameters": [<definition for name, required=true>]},
      {"parameters": [<definition for description, required=true>]},
      {"parameters": [<definition for price, required=true>]}
    ]
  }
}
```
to teach w3af about the combinations of parameters that can work together.