### PR TITLE
retirejs.py wrong version of retirejs indicated and in history.py msgpack.dump call varaiables backwards

### DIFF
--- a/w3af/core/controllers/dependency_check/external/retirejs.py
+++ b/w3af/core/controllers/dependency_check/external/retirejs.py
@@ -24,7 +24,7 @@ import subprocess
 from w3af.core.controllers.misc.which import which
 
 
-SUPPORTED_RETIREJS = '2.'
+SUPPORTED_RETIREJS = '1.'
 
 
 def retirejs_is_installed():

--- a/w3af/core/ui/gui/history.py
+++ b/w3af/core/ui/gui/history.py
@@ -66,7 +66,7 @@ class HistorySuggestion(object):
                     # msgpack to prevent deserialization issues
                     # https://github.com/andresriancho/w3af/issues/17807
                     #
-                    msgpack.dump(file(filename, 'wb'), self.history)
+                    msgpack.dump(self.history, file(filename, 'wb'))
 
     def get_texts(self):
         """Provides the texts, ordered by relevance.

--- a/w3af/core/ui/gui/history.py
+++ b/w3af/core/ui/gui/history.py
@@ -59,7 +59,7 @@ class HistorySuggestion(object):
                     # the next time the user executes the GUI
                     #
                     self.history = {}
-                    msgpack.dump(file(filename, 'wb'), {})
+                    msgpack.dump({}, file(filename, 'wb'))
                 else:
                     #
                     # We were able to read using pickle, migrate the file to


### PR DESCRIPTION
Kali linux 2019* definitly has this issue and probably debian and ubuntu considering the relationship

changed retirejs.py because every os I tried failed because the version of "retire: or retirejs did not meet requirements according to this file. I looked in NPM there is no version 2.* of retirejs available 

changed history.py because 
Basically a dict object was being past to a function that expected something with a .write attribute
the file object has write attribute so I figure the intent was to use that, so I switch around the file obj and "{}" obj because it made sense.  After that it started no problem


Traceback (most recent call last):
  File "/opt/git/w3af/w3af_gui", line 110, in <module>
    _main()
  File "/opt/git/w3af/w3af_gui", line 106, in _main
    sys.exit(main())
  File "/opt/git/w3af/w3af_gui", line 101, in main
    gui_main(profile, doupdate)
  File "/opt/git/w3af/w3af/core/ui/gui/main.py", line 936, in main
    MainApp(profile, do_upd)
  File "/opt/git/w3af/w3af/core/ui/gui/main.py", line 413, in __init__
    self.pcbody = pluginconfig.PluginConfigBody(self, self.w3af)
  File "/opt/git/w3af/w3af/core/ui/gui/pluginconfig.py", line 601, in __init__
    alertmodif=mainwin.profile_changed)
  File "/opt/git/w3af/w3af/core/ui/gui/entries.py", line 468, in __init__
    alertmodif=alertmodif)
  File "/opt/git/w3af/w3af/core/ui/gui/entries.py", line 405, in __init__
    self.hist = history.HistorySuggestion(historyfile)
  File "/opt/git/w3af/w3af/core/ui/gui/history.py", line 62, in __init__
    msgpack.dump(file(filename, 'wb'), {})
  File "/usr/local/lib/python2.7/dist-packages/msgpack/__init__.py", line 38, in pack
    stream.write(packer.pack(o))
AttributeError: 'dict' object has no attribute 'write'