### PR TITLE
fix an error occurred while calling the function generate_404_by_shuffle

### DIFF
--- a/w3af/core/controllers/core_helpers/not_found/generate_404.py
+++ b/w3af/core/controllers/core_helpers/not_found/generate_404.py
@@ -131,8 +131,8 @@ def generate_404_by_shuffle(filename, extension, seed):
 
     filename = [c for c in filename]
 
-    mod_filename = random.shuffle(filename)
-    mod_filename = ''.join(mod_filename)
+    random.shuffle(filename)
+    mod_filename = ''.join(filename)
 
     return append_extension_if_exists(mod_filename, extension)
 


### PR DESCRIPTION
Error Message：
```
A "TypeError" exception was found while running crawl.web_spider on "Method: GET | https://domain/". The exception was: "can only join an iterable" at None:None():None. The full traceback is:

Traceback (most recent call last):
  File "/root/tools/w3af/w3af/core/controllers/threads/threadpool.py", line 278, in __call__
    result = (True, func(*args, **kwds))
  File "/root/tools/w3af/w3af/core/controllers/threads/pool276.py", line 67, in mapstar
    return map(*args)
  File "/root/tools/w3af/w3af/core/controllers/threads/threadpool.py", line 55, in __call__
    return self.func_orig(*args)
  File "/root/tools/w3af/w3af/plugins/crawl/web_spider.py", line 374, in _verify_reference
    if not is_404(resp):
  File "/root/tools/w3af/w3af/core/controllers/core_helpers/fingerprint_404.py", line 412, in is_404
    return fp_404_db.is_404(http_response)
  File "/root/tools/w3af/w3af/core/controllers/core_helpers/not_found/decorators.py", line 123, in __call__
    return self._function(*args, **kwargs)
  File "/root/tools/w3af/w3af/core/controllers/core_helpers/not_found/decorators.py", line 58, in __call__
    result = self._function(*args, **kwargs)
  File "/root/tools/w3af/w3af/core/controllers/core_helpers/fingerprint_404.py", line 99, in is_404
    if self._is_404_complex(http_response):
  File "/root/tools/w3af/w3af/core/controllers/core_helpers/fingerprint_404.py", line 186, in _is_404_complex
    known_404 = self._get_404_response(http_response, query, debugging_id)
  File "/root/tools/w3af/w3af/core/controllers/core_helpers/fingerprint_404.py", line 393, in _get_404_response
    debugging_id)
  File "/root/tools/w3af/w3af/core/controllers/core_helpers/not_found/generate_404.py", line 261, in send_request_generate_404
    url_404 = get_url_for_404_request(http_response, seed=seed)
  File "/root/tools/w3af/w3af/core/controllers/core_helpers/not_found/generate_404.py", line 280, in get_url_for_404_request
    relative_url = generate_404_filename(filename, seed=seed)
  File "/root/tools/w3af/w3af/core/controllers/core_helpers/not_found/generate_404.py", line 240, in generate_404_filename
    return generate_404_by_shuffle(orig_filename, extension, seed=seed)
  File "/root/tools/w3af/w3af/core/controllers/core_helpers/not_found/generate_404.py", line 135, in generate_404_by_shuffle
    mod_filename = ''.join(mod_filename)
TypeError: can only join an iterable
```
Source Code:
```
    mod_filename = random.shuffle(filename)
    mod_filename = ''.join(mod_filename)
```

Like many list methods, ```random.shuffle()``` , acts in-place , and therefore returns None. so ```mod_filename``` is therefore None, hence the error.