### PR TITLE
Fix crash when we try to free() terminated chrome instance in pool

### DIFF
--- a/w3af/core/controllers/chrome/instrumented/instrumented_base.py
+++ b/w3af/core/controllers/chrome/instrumented/instrumented_base.py
@@ -59,7 +59,6 @@ class InstrumentedChromeBase(object):
         self.http_traffic_queue = http_traffic_queue
 
         self.debugging_id = None
-        self.is_terminated = False
 
         self.proxy = self.start_proxy()
         self.chrome_process = self.start_chrome_process()
@@ -284,7 +283,6 @@ class InstrumentedChromeBase(object):
         self.proxy = None
         self.chrome_process = None
         self.chrome_conn = None
-        self.is_terminated = True
 
     def get_pid(self):
         try:

--- a/w3af/core/controllers/chrome/instrumented/instrumented_base.py
+++ b/w3af/core/controllers/chrome/instrumented/instrumented_base.py
@@ -59,6 +59,7 @@ class InstrumentedChromeBase(object):
         self.http_traffic_queue = http_traffic_queue
 
         self.debugging_id = None
+        self.is_terminated = False
 
         self.proxy = self.start_proxy()
         self.chrome_process = self.start_chrome_process()
@@ -283,6 +284,7 @@ class InstrumentedChromeBase(object):
         self.proxy = None
         self.chrome_process = None
         self.chrome_conn = None
+        self.is_terminated = True
 
     def get_pid(self):
         try:

--- a/w3af/core/controllers/chrome/pool.py
+++ b/w3af/core/controllers/chrome/pool.py
@@ -269,6 +269,10 @@ class ChromePool(object):
         return self._in_use
 
     def free(self, chrome):
+        if chrome.is_terminated:
+            msg = 'Chrome instance is already terminated'
+            om.out.debug(msg)
+            return
         chrome.free_count += 1
 
         debugging_id = chrome.get_debugging_id()

--- a/w3af/core/controllers/chrome/pool.py
+++ b/w3af/core/controllers/chrome/pool.py
@@ -269,7 +269,7 @@ class ChromePool(object):
         return self._in_use
 
     def free(self, chrome):
-        if chrome.is_terminated:
+        if not chrome.chrome_process:
             msg = 'Chrome instance is already terminated'
             om.out.debug(msg)
             return

--- a/w3af/core/controllers/chrome/tests/test_pool.py
+++ b/w3af/core/controllers/chrome/tests/test_pool.py
@@ -65,6 +65,15 @@ class TestChromePool(unittest.TestCase):
         self.assertIn(chrome, self.pool._free)
         self.assertNotIn(chrome, self.pool._in_use)
 
+    def test_freeing_terminated_chrome_wont_cause_crash(self):
+        """
+        Regression test to prevent raising exception when pool.free() is called
+        on already terminated chrome instance.
+        """
+        chrome = self.pool.get(self.http_traffic_queue)
+        self.pool.remove(chrome, 'unittest')
+        self.pool.free(chrome)  # previously this raised AttributeError
+
     def test_remove(self):
         chrome = self.pool.get(self.http_traffic_queue)
         self.pool.remove(chrome, 'unittest')


### PR DESCRIPTION
Sometimes during scans the below exception was raised. It was probably caused by calling `pool.free()` on already terminated chrome instance.

```
A "AttributeError" exception was found while running crawl.web_spider on "Method: GET | https://domain/images/favicon.png". The exception was: "'NoneType' object has no attribute 'set_debugging_id'" at /usr/local/w3af/w3af/plugins/crawl/web_spider.py:_raise_chrome_crawler_exception()():633. The full traceback is:

Traceback (most recent call last):
  File "/usr/local/w3af/w3af/core/controllers/chrome/crawler/main.py", line 299, in _crawl_with_strategy_wrapper
    run_ro_strategies)
  File "/usr/local/w3af/w3af/core/controllers/chrome/crawler/main.py", line 338, in _crawl_with_strategy
    self._chrome_pool.free(chrome)
  File "/usr/local/w3af/w3af/core/controllers/chrome/pool.py", line 275, in free
    chrome.set_debugging_id(None)
  File "/usr/local/w3af/w3af/core/controllers/chrome/instrumented/main.py", line 94, in set_debugging_id
    super(InstrumentedChrome, self).set_debugging_id(debugging_id)
  File "/usr/local/w3af/w3af/core/controllers/chrome/instrumented/instrumented_base.py", line 188, in set_debugging_id
    self.chrome_conn.set_debugging_id(debugging_id)
AttributeError: 'NoneType' object has no attribute 'set_debugging_id'
```