### PR TITLE
Fix/recursive crawl

### DIFF
--- a/w3af/core/controllers/misc_settings.py
+++ b/w3af/core/controllers/misc_settings.py
@@ -31,7 +31,7 @@ from w3af.core.data.options.opt_factory import opt_factory
 from w3af.core.data.options.option_list import OptionList
 from w3af.core.data.db.variant_db import (PATH_MAX_VARIANTS,
                                           PARAMS_MAX_VARIANTS,
-                                          MAX_EQUAL_FORM_VARIANTS)
+                                          MAX_EQUAL_FORM_VARIANTS, PATH_MAX_LOOP)
 from w3af.core.data.options.option_types import (URL_LIST, COMBO, BOOL, LIST,
                                                  STRING, INT, FORM_ID_LIST)
 
@@ -71,6 +71,7 @@ class MiscSettings(Configurable):
         cf.cf.save('form_fuzzing_mode', 'tmb')
 
         cf.cf.save('path_max_variants', PATH_MAX_VARIANTS)
+        cf.cf.save('path_max_loop', PATH_MAX_LOOP)
         cf.cf.save('params_max_variants', PARAMS_MAX_VARIANTS)
         cf.cf.save('max_equal_form_variants', MAX_EQUAL_FORM_VARIANTS)
 

--- a/w3af/core/data/db/tests/test_variant_db.py
+++ b/w3af/core/data/db/tests/test_variant_db.py
@@ -484,3 +484,29 @@ class TestVariantDB(unittest.TestCase):
         for i in xrange(MAX_EQUAL_FORM_VARIANTS * 2):
             fri = create_fuzzable_request(i)
             self.assertTrue(self.vdb.append(fri))
+
+    def test_request_is_looped_method(self):
+        looped_url = 'http://example.com/redirect/redirect/redirect/redirect/redirect/index.html'
+        too_short_looped_url = 'http://example.com/redirect/redirect/index.html'
+        not_looped_url1 = 'http://example.com/one/two/3/4/5/index.html'
+        not_looped_url2 = (
+            'http://example.com/good/redirect/redirect/redirect/redirect/index.html'
+        )
+        not_looped_url3 = (
+            'http://example.com/redirect/redirect/redirect/redirect/good/index.html'
+        )
+
+        req = fr(URL(looped_url))
+        self.assertTrue(self.vdb._request_is_looped(req))
+
+        req = fr(URL(too_short_looped_url))
+        self.assertFalse(self.vdb._request_is_looped(req))
+
+        req = fr(URL(not_looped_url1))
+        self.assertFalse(self.vdb._request_is_looped(req))
+
+        req = fr(URL(not_looped_url2))
+        self.assertFalse(self.vdb._request_is_looped(req))
+
+        req = fr(URL(not_looped_url3))
+        self.assertFalse(self.vdb._request_is_looped(req))

--- a/w3af/plugins/crawl/web_spider.py
+++ b/w3af/plugins/crawl/web_spider.py
@@ -19,7 +19,6 @@ along with w3af; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 """
-import hashlib
 import re
 import Queue
 import threading
@@ -73,7 +72,6 @@ class web_spider(CrawlPlugin):
         self._target_domain = None
         self._already_filled_form = ScalableBloomFilter()
         self._variant_db = VariantDB()
-        self._found_responses = {}
 
         # User configured variables
         self._ignore_regex = ''

--- a/w3af/plugins/crawl/web_spider.py
+++ b/w3af/plugins/crawl/web_spider.py
@@ -434,57 +434,12 @@ class web_spider(CrawlPlugin):
                                                                  fuzzable_req,
                                                                  http_response,
                                                                  debugging_id)
-        is_response_unique = self._ensure_response_is_unique(http_response.body)
-        if not is_response_unique:
-            message = 'URL already crawled by web_spider: {} (did: {})'.format(
-                fuzzable_req.get_uri(),
-                debugging_id,
-            )
-            om.out.debug(message)
-            return
 
         self.worker_pool.map_multi_args(
             self._verify_reference,
             url_to_verify_generator
         )
 
-    def _ensure_response_is_unique(self, response_body):
-        """
-        Sometimes JS crawler gets cheated by the website and crawl the same response
-        over and over again but under another url.
-
-        We want to store hash of response body, so if the same hash will occur again
-        we'll know the response isn't unique. Calculating hash is CPU-expensive,
-        so we store only length of response in self._found_responses dict.
-        If we find second response with same length then we calculate hash for it
-        and store it like
-        {
-            123: [],  # no hash, the resp with length 123 was found only once
-            24: ['dsf42434lkaf9j@3ls', 'd3#-dfr3'],  # two different responses with
-            # the length 24 was found, so we store their hashes
-        }
-
-        :param str response_body: the body of response from the URL we crawl right now
-        :returns bool: return True if response body is brand new and unique and False if
-        we have already crawled the same response body.
-        """
-        # We want to first store only length of response as it's the fastest way
-        # to check if they're quite unique
-        body_length = len(response_body)
-
-        # Check if response with same length was already crawled
-        similar_response_hashes = self._found_responses.get(body_length)
-        if similar_response_hashes:
-            # If there was response with same length let's calculate checksum of our response
-            response_hash = hashlib.md5(response_body)
-            if response_hash not in similar_response_hashes:
-                # We store hashes of responses with same length
-                similar_response_hashes.append(response_hash)
-                return False
-            return True
-        self._found_responses[body_length] = []
-        return False
-    
     @property
     def _chrome_crawler(self):
         if self._chrome_crawler_inst is None:


### PR DESCRIPTION
There are Vue/React/Angular pages which instead of showing 404 error message redirect us to the main page (like `this.$route.replace('/')`). When we scan the page like this JS crawler goes for infinite loop and discovers deeply nested URLs forever with the same response.

Here's simple fix which can potentially prevent this bug for most cases.
We can't use `VariantDB.MAX_PATH_VARIANTS` as it would affect many crawling aspects and limit crawling flow. We want to limit only *recursively nested path crawling*, not the *path variants crawling*.

## TODO
- [ ] ensure `_request_is_looped` in VariantDB won't stop whole scan too early. What if we'll detect looped URL before crawling the rest of URLs?
- [ ] test if it won't destroy proper crawling (false positives)
- [x] what if the main page includes e.g. current timestamp? Response hash could be different

Also I wasn't able to write an integration test for this issue, as I wasn't able to simulate the server URL resolving conditions. Blocked by https://github.com/andresriancho/w3af/issues/18430.
But finally I was able to at least write unit test, so hopefully it can be enough for now.