### PR TITLE
Fix/GitPython bump version to 2.1.15

### DIFF
--- a/extras/docker/Dockerfile
+++ b/extras/docker/Dockerfile
@@ -50,7 +50,7 @@ RUN pip install --index-url=https://pypi.python.org/simple/ --upgrade pip
 #
 #tblib==0.2.0
 #
-RUN pip install setuptools-git>=1.1 pyClamd==0.4.0 PyGithub==1.21.0 GitPython==2.1.3 \
+RUN pip install setuptools-git>=1.1 pyClamd==0.4.0 PyGithub==1.21.0 GitPython==2.1.15 \
         pybloomfiltermmap==0.3.14 esmre==0.3.1 phply==0.9.1 nltk==3.0.1 chardet==3.0.4 \
         pdfminer==20140328 futures==3.2.0 pyOpenSSL==18.0.0 scapy==2.4.0 guess-language==0.2 \
         cluster==1.1.1b3 msgpack-python==0.5.6 python-ntlm==1.0.1 halberd==0.2.4 \

--- a/w3af/core/controllers/dependency_check/requirements.py
+++ b/w3af/core/controllers/dependency_check/requirements.py
@@ -27,7 +27,7 @@ GUI = 2
 
 CORE_PIP_PACKAGES = [PIPDependency('pyclamd', 'pyClamd', '0.4.0'),
                      PIPDependency('github', 'PyGithub', '1.21.0'),
-                     PIPDependency('git.util', 'GitPython', '2.1.3'),
+                     PIPDependency('git.util', 'GitPython', '2.1.15'),
                      PIPDependency('pybloomfilter', 'pybloomfiltermmap', '0.3.14'),
                      PIPDependency('phply', 'phply', '0.9.1'),
                      PIPDependency('nltk', 'nltk', '3.0.1'),


### PR DESCRIPTION
Current version of GitPython in the repository (2.1.3) fails to install due to missing dependencies (`gitdb==4.0.1`):
```
ERROR: Could not find a version that satisfies the requirement gitdb>=4.0.1 (from gitdb2>=2.0.0->GitPython==2.1.3) (from versions: 0.5.0, 0.5.1, 0.5.2, 0.5.3, 0.5.4, 0.6.0, 0.6.1, 0.6.2, 0.6.3, 0.6.4)
ERROR: No matching distribution found for gitdb>=4.0.1 (from gitdb2>=2.0.0->GitPython==2.1.3)
```
Same error appears when running `extras/docker/docker-build-local.sh`.
Issue is fixed after bumping `GitPython` to 2.1.15 version.

That issue probably does not affect existing installations. To reproduce it, create new virtual environment or invalidate docker cache, then run script generated by `./w3af_console` or run `extra/docker/docker-build-local.sh`.