### PR TITLE
Feature/improve autocomplete js

### DIFF
--- a/w3af/core/controllers/chrome/devtools/exceptions.py
+++ b/w3af/core/controllers/chrome/devtools/exceptions.py
@@ -27,3 +27,11 @@ class ChromeInterfaceException(Exception):
 
 class ChromeInterfaceTimeout(Exception):
     pass
+
+
+class ChromeScriptRuntimeException(Exception):
+    def __init__(self, message, function_called=None, *args):
+        if function_called:
+            message = "function: {}, exception: {}".format(function_called, message)
+        super(ChromeScriptRuntimeException, self).__init__(message, *args)
+    pass

--- a/w3af/core/controllers/chrome/instrumented/frame_manager.py
+++ b/w3af/core/controllers/chrome/instrumented/frame_manager.py
@@ -166,7 +166,7 @@ class FrameManager(object):
         # URL all the child frames are removed from Chrome, we should remove
         # them from our code too to mirror state
         if frame:
-            for child_frame_id, child_frame in frame.child_frames:
+            for child_frame_id, child_frame in frame.child_frames.items():
                 child_frame.detach(self)
 
             frame.set_navigated()

--- a/w3af/core/controllers/chrome/instrumented/main.py
+++ b/w3af/core/controllers/chrome/instrumented/main.py
@@ -297,11 +297,20 @@ class InstrumentedChrome(InstrumentedChromeBase):
 
         return True
 
-    def get_login_forms(self):
+    def get_login_forms(self, exact_css_selectors):
         """
+        :param dict exact_css_selectors: Optional parameter containing css selectors
+        for part of form like username input or login button.
         :return: Yield LoginForm instances
         """
-        result = self.js_runtime_evaluate('window._DOMAnalyzer.getLoginForms()')
+        func = (
+            'window._DOMAnalyzer.getLoginForms("{}", "{}")'
+        )
+        func = func.format(
+            exact_css_selectors.get('username_input', ''),
+            exact_css_selectors.get('login_button', ''),
+        )
+        result = self.js_runtime_evaluate(func)
 
         if result is None:
             raise EventTimeout('The event execution timed out')
@@ -316,11 +325,20 @@ class InstrumentedChrome(InstrumentedChromeBase):
 
             yield login_form
 
-    def get_login_forms_without_form_tags(self):
+    def get_login_forms_without_form_tags(self, exact_css_selectors):
         """
+        :param dict exact_css_selectors: Optional parameter containing css selectors
+        for part of form like username input or login button.
         :return: Yield LoginForm instances
         """
-        result = self.js_runtime_evaluate('window._DOMAnalyzer.getLoginFormsWithoutFormTags()')
+        func = (
+            'window._DOMAnalyzer.getLoginFormsWithoutFormTags("{}", "{}")'
+        )
+        func = func.format(
+            exact_css_selectors.get('username_input', ''),
+            exact_css_selectors.get('login_button', ''),
+        )
+        result = self.js_runtime_evaluate(func)
 
         if result is None:
             raise EventTimeout('The event execution timed out')

--- a/w3af/core/controllers/chrome/instrumented/main.py
+++ b/w3af/core/controllers/chrome/instrumented/main.py
@@ -425,9 +425,9 @@ class InstrumentedChrome(InstrumentedChromeBase):
         if result is None:
             return None
 
-        node_ids = result.get('result', {}).get('nodeIds', None)
+        node_ids = result.get('result', {}).get('nodeIds')
 
-        if node_ids is None:
+        if not node_ids:
             msg = ('The call to chrome.focus() failed.'
                    ' CSS selector "%s" returned no nodes (did: %s)')
             args = (selector, self.debugging_id)

--- a/w3af/core/controllers/chrome/js/dom_analyzer.js
+++ b/w3af/core/controllers/chrome/js/dom_analyzer.js
@@ -900,15 +900,9 @@ var _DOMAnalyzer = _DOMAnalyzer || {
         if (!result.length) {
             result = document.querySelectorAll("button[type='submit']", parentElement);
         }
-        // Maybe it's just normal button with innerText: 'Login'...
+        // Maybe it's just normal button without type="submit"...
         if (!result.length) {
-            result = [];
-            let buttons = document.querySelectorAll('button', parentElement);
-            for (let button of buttons) {
-                if (button.innerText.toLocaleLowerCase().includes('log')) {
-                    result.push(button);
-                }
-            }
+            result = document.querySelectorAll('button', parentElement);
         }
         return result;
     },

--- a/w3af/core/controllers/chrome/js/dom_analyzer.js
+++ b/w3af/core/controllers/chrome/js/dom_analyzer.js
@@ -1049,6 +1049,11 @@ var _DOMAnalyzer = _DOMAnalyzer || {
         return JSON.stringify(login_forms);
     },
 
+    clickOnSelector(exactSelector) {
+        let element = document.querySelector(exactSelector);
+        element.click();
+    },
+
     sliceAndSerialize: function (filtered_event_listeners, start, count) {
         return JSON.stringify(filtered_event_listeners.slice(start, start + count));
     },

--- a/w3af/core/controllers/chrome/js/dom_analyzer.js
+++ b/w3af/core/controllers/chrome/js/dom_analyzer.js
@@ -993,7 +993,7 @@ var _DOMAnalyzer = _DOMAnalyzer || {
     * @param {String} submitButtonCssSelector - CSS selector for submit button. If
     * provided we won't try to find submit button autmatically.
     */
-    getLoginFormsWithoutFormTags: function () {
+    getLoginFormsWithoutFormTags: function (usernameCssSelector = '', submitButtonCssSelector = '') {
         let login_forms = [];
 
         // First we identify the password fields

--- a/w3af/core/controllers/chrome/js/dom_analyzer.js
+++ b/w3af/core/controllers/chrome/js/dom_analyzer.js
@@ -1052,6 +1052,7 @@ var _DOMAnalyzer = _DOMAnalyzer || {
     clickOnSelector(exactSelector) {
         let element = document.querySelector(exactSelector);
         element.click();
+        return 'success'
     },
 
     sliceAndSerialize: function (filtered_event_listeners, start, count) {

--- a/w3af/core/controllers/chrome/js/dom_analyzer.js
+++ b/w3af/core/controllers/chrome/js/dom_analyzer.js
@@ -330,7 +330,7 @@ var _DOMAnalyzer = _DOMAnalyzer || {
         if( !_DOMAnalyzer.eventIsValidForTagName( tag_name, type ) ) return false;
 
         let selector = OptimalSelect.getSingleSelector(element);
-        
+
         // node_type is https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType#Node_type_constants
         _DOMAnalyzer.event_listeners.push({"tag_name": tag_name,
                                            "node_type": element.nodeType,
@@ -866,6 +866,44 @@ var _DOMAnalyzer = _DOMAnalyzer || {
     },
 
     /**
+     * This is naive function which takes parentElement (the login form) and
+     * tries to find username input field within it.
+     * @param  {Node} parentElement - parent element to scope to document.querySelectorAll()
+     * @returns {NodeList} - result of querySelectorAll()
+     */
+    _getUsernameInput(parentElement) {
+        result = document.querySelectorAll("input[type='email']", parentElement);
+        if (!result.length) {
+            result = document.querySelectorAll("input[type='text']", parentElement);
+        }
+        return result;
+    },
+
+    /**
+     * This is naive function which takes parentElement (the login form) and tries
+     * to find submit button within it.
+     * @param  {Node} parentElement - parent element to scope to document.querySelectorAll()
+     * @returns {NodeList} - result of querySelectorAll()
+     */
+    _getSubmitButton(parentElement) {
+        result = document.querySelectorAll("input[type='submit']", parentElement);
+        if (!result.length) {
+            result = document.querySelectorAll("button[type='submit']", parentElement);
+        }
+        // Maybe it's just normal button with innerText: 'Login'...
+        if (!result.length) {
+            result = [];
+            let buttons = document.querySelectorAll('button', parentElement);
+            for (let button of buttons) {
+                if (button.innerText.toLocaleLowerCase().includes('log')) {
+                    result.push(button);
+                }
+            }
+        }
+        return result;
+    },
+
+    /**
     * Return the CSS selector for the login forms which exist in the DOM.
     *
     * For this method login forms are defined as:
@@ -898,7 +936,7 @@ var _DOMAnalyzer = _DOMAnalyzer || {
             let form = forms[0];
 
             // Finally we confirm that the form has a type=text input
-            let text_fields = document.querySelectorAll("input[type='text']", form)
+            let text_fields = _getUsernameInput(form);
 
             // Zero text fields is most likely a password-only login form
             // Two text fields or more is most likely a registration from
@@ -906,7 +944,7 @@ var _DOMAnalyzer = _DOMAnalyzer || {
             if (text_fields.length !== 1) continue;
 
             // And if there is a submit button I want that selector too
-            let submit_fields = document.querySelectorAll("input[type='submit']", form)
+            let submit_fields = _getSubmitButton(form);
             let submit_selector = null;
 
             if (submit_fields.length !== 0) {
@@ -962,7 +1000,7 @@ var _DOMAnalyzer = _DOMAnalyzer || {
                 // go up one more level, and so one.
                 //
                 // Find if this parent has a type=text input
-                let text_fields = document.querySelectorAll("input[type='text']", parent)
+                let text_fields = _getUsernameInput(parent)
 
                 // Zero text fields is most likely a password-only login form
                 // Two text fields or more is most likely a registration from
@@ -974,7 +1012,7 @@ var _DOMAnalyzer = _DOMAnalyzer || {
                 }
 
                 // And if there is a submit button I want that selector too
-                let submit_fields = document.querySelectorAll("input[type='submit']", parent)
+                let submit_fields = _getSubmitButton(parent)
                 let submit_selector = null;
 
                 if (submit_fields.length !== 0) {

--- a/w3af/core/controllers/chrome/js/dom_analyzer.js
+++ b/w3af/core/controllers/chrome/js/dom_analyzer.js
@@ -868,10 +868,15 @@ var _DOMAnalyzer = _DOMAnalyzer || {
     /**
      * This is naive function which takes parentElement (the login form) and
      * tries to find username input field within it.
-     * @param  {Node} parentElement - parent element to scope to document.querySelectorAll()
+     * @param {Node} parentElement - parent element to scope to document.querySelectorAll()
+     * @param {String} exactSelector - optional CSS selector. If provided prevents
+     * using standard selectors
      * @returns {NodeList} - result of querySelectorAll()
      */
-    _getUsernameInput(parentElement) {
+    _getUsernameInput(parentElement, exactSelector = '') {
+        if (exactSelector) {
+            return document.querySelectorAll(exactSelector, parentElement);
+        }
         result = document.querySelectorAll("input[type='email']", parentElement);
         if (!result.length) {
             result = document.querySelectorAll("input[type='text']", parentElement);
@@ -882,10 +887,15 @@ var _DOMAnalyzer = _DOMAnalyzer || {
     /**
      * This is naive function which takes parentElement (the login form) and tries
      * to find submit button within it.
-     * @param  {Node} parentElement - parent element to scope to document.querySelectorAll()
+     * @param {Node} parentElement - parent element to scope to document.querySelectorAll()
+     * @param {String} exactSelector - optional CSS selector. If provided prevents
+     * using standard selectors
      * @returns {NodeList} - result of querySelectorAll()
      */
-    _getSubmitButton(parentElement) {
+    _getSubmitButton(parentElement, exactSelector = '') {
+        if (exactSelector) {
+            return document.querySelectorAll(exactSelector, parentElement);
+        }
         result = document.querySelectorAll("input[type='submit']", parentElement);
         if (!result.length) {
             result = document.querySelectorAll("button[type='submit']", parentElement);
@@ -912,8 +922,12 @@ var _DOMAnalyzer = _DOMAnalyzer || {
     *       - <input type=text>, and
     *       - <input type=password>
     *
+    * @param {String} usernameCssSelector - CSS selector for username input. If
+    * provided we won't try to find username input automatically.
+    * @param {String} submitButtonCssSelector - CSS selector for submit button. If
+    * provided we won't try to find submit button autmatically.
     */
-    getLoginForms: function () {
+    getLoginForms: function (usernameCssSelector = '', submitButtonCssSelector = '') {
         let login_forms = [];
 
         // First we identify the forms with a password field using a descendant Selector
@@ -936,7 +950,7 @@ var _DOMAnalyzer = _DOMAnalyzer || {
             let form = forms[0];
 
             // Finally we confirm that the form has a type=text input
-            let text_fields = _getUsernameInput(form);
+            let text_fields = this._getUsernameInput(form, usernameCssSelector);
 
             // Zero text fields is most likely a password-only login form
             // Two text fields or more is most likely a registration from
@@ -944,7 +958,7 @@ var _DOMAnalyzer = _DOMAnalyzer || {
             if (text_fields.length !== 1) continue;
 
             // And if there is a submit button I want that selector too
-            let submit_fields = _getSubmitButton(form);
+            let submit_fields = this._getSubmitButton(form, submitButtonCssSelector);
             let submit_selector = null;
 
             if (submit_fields.length !== 0) {
@@ -974,6 +988,10 @@ var _DOMAnalyzer = _DOMAnalyzer || {
     *       - <input type=text>, and
     *       - <input type=password>
     *
+    * @param {String} usernameCssSelector - CSS selector for username input. If
+    * provided we won't try to find username input automatically.
+    * @param {String} submitButtonCssSelector - CSS selector for submit button. If
+    * provided we won't try to find submit button autmatically.
     */
     getLoginFormsWithoutFormTags: function () {
         let login_forms = [];
@@ -1000,7 +1018,7 @@ var _DOMAnalyzer = _DOMAnalyzer || {
                 // go up one more level, and so one.
                 //
                 // Find if this parent has a type=text input
-                let text_fields = _getUsernameInput(parent)
+                let text_fields = this._getUsernameInput(parent, usernameCssSelector);
 
                 // Zero text fields is most likely a password-only login form
                 // Two text fields or more is most likely a registration from
@@ -1012,7 +1030,7 @@ var _DOMAnalyzer = _DOMAnalyzer || {
                 }
 
                 // And if there is a submit button I want that selector too
-                let submit_fields = _getSubmitButton(parent)
+                let submit_fields = this._getSubmitButton(parent, submitButtonCssSelector)
                 let submit_selector = null;
 
                 if (submit_fields.length !== 0) {

--- a/w3af/core/controllers/chrome/login/find_form/main.py
+++ b/w3af/core/controllers/chrome/login/find_form/main.py
@@ -36,14 +36,21 @@ class FormFinder(object):
         self.chrome = chrome
         self.debugging_id = debugging_id
 
-    def find_forms(self):
+    def find_forms(self, css_selectors=None):
         """
+        :param dict css_selectors: optional dict of css selectors used to find
+        elements of form (like username input or login button)
         :return: Yield forms as they are found by each strategy
         """
+        if css_selectors:
+            msg = 'Form finder uses the CSS selectors: "%s" (did: %s)'
+            args = (css_selectors, self.debugging_id)
+            om.out.debug(msg % args)
+
         identified_forms = []
 
         for strategy_klass in self.STRATEGIES:
-            strategy = strategy_klass(self.chrome, self.debugging_id)
+            strategy = strategy_klass(self.chrome, self.debugging_id, css_selectors)
 
             try:
                 for form in strategy.find_forms():

--- a/w3af/core/controllers/chrome/login/find_form/main.py
+++ b/w3af/core/controllers/chrome/login/find_form/main.py
@@ -63,6 +63,6 @@ class FormFinder(object):
             except Exception as e:
                 msg = 'Form finder strategy %s raised exception: "%s" (did: %s)'
                 args = (strategy.get_name(),
-                        e,
+                        repr(e),
                         self.debugging_id)
                 om.out.debug(msg % args)

--- a/w3af/core/controllers/chrome/login/find_form/main.py
+++ b/w3af/core/controllers/chrome/login/find_form/main.py
@@ -53,6 +53,7 @@ class FormFinder(object):
             strategy = strategy_klass(self.chrome, self.debugging_id, css_selectors)
 
             try:
+                strategy.prepare()
                 for form in strategy.find_forms():
                     if form in identified_forms:
                         continue

--- a/w3af/core/controllers/chrome/login/find_form/strategies/base_find_form_strategy.py
+++ b/w3af/core/controllers/chrome/login/find_form/strategies/base_find_form_strategy.py
@@ -1,0 +1,18 @@
+class BaseFindFormStrategy:
+    def __init__(self, chrome, debugging_id, exact_css_selectors=None):
+        """
+        :param InstrumentedChrome chrome:
+        :param String debugging_id:
+        :param dict exact_css_selectors: Optional parameter containing css selectors
+        for part of form like username input or login button.
+        """
+        self.chrome = chrome
+        self.debugging_id = debugging_id
+        self.exact_css_selectors = exact_css_selectors or {}
+
+    def find_forms(self):
+        raise NotImplementedError
+
+    @staticmethod
+    def get_name():
+        return 'BaseFindFormStrategy'

--- a/w3af/core/controllers/chrome/login/find_form/strategies/base_find_form_strategy.py
+++ b/w3af/core/controllers/chrome/login/find_form/strategies/base_find_form_strategy.py
@@ -1,3 +1,6 @@
+from w3af.core.controllers.chrome.instrumented.exceptions import EventTimeout
+
+
 class BaseFindFormStrategy:
     def __init__(self, chrome, debugging_id, exact_css_selectors=None):
         """
@@ -9,6 +12,20 @@ class BaseFindFormStrategy:
         self.chrome = chrome
         self.debugging_id = debugging_id
         self.exact_css_selectors = exact_css_selectors or {}
+
+    def prepare(self):
+        """
+        :raises EventTimeout:
+        Hook called before find_forms()
+        """
+        form_activator_selector = self.exact_css_selectors.get('form_activator')
+        if form_activator_selector:
+            func = 'window._DOMAnalyzer.clickOnSelector({})'.format(
+                form_activator_selector
+            )
+            result = self.chrome.js_runtime_evaluate(func)
+            if result is None:
+                raise EventTimeout('The event execution timed out')
 
     def find_forms(self):
         raise NotImplementedError

--- a/w3af/core/controllers/chrome/login/find_form/strategies/base_find_form_strategy.py
+++ b/w3af/core/controllers/chrome/login/find_form/strategies/base_find_form_strategy.py
@@ -20,8 +20,8 @@ class BaseFindFormStrategy:
         """
         form_activator_selector = self.exact_css_selectors.get('form_activator')
         if form_activator_selector:
-            func = 'window._DOMAnalyzer.clickOnSelector({})'.format(
-                form_activator_selector
+            func = 'window._DOMAnalyzer.clickOnSelector("{}")'.format(
+                form_activator_selector.replace('"', '\\"')
             )
             result = self.chrome.js_runtime_evaluate(func)
             if result is None:

--- a/w3af/core/controllers/chrome/login/find_form/strategies/form_tag.py
+++ b/w3af/core/controllers/chrome/login/find_form/strategies/form_tag.py
@@ -19,12 +19,11 @@ along with w3af; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 """
+from w3af.core.controllers.chrome.login.find_form.strategies.base_find_form_strategy import \
+    BaseFindFormStrategy
 
 
-class FormTagStrategy(object):
-    def __init__(self, chrome, debugging_id):
-        self.chrome = chrome
-        self.debugging_id = debugging_id
+class FormTagStrategy(BaseFindFormStrategy):
 
     def find_forms(self):
         """
@@ -37,7 +36,7 @@ class FormTagStrategy(object):
         """
         :return: Yield forms that have username, password and submit inputs
         """
-        for login_form in self.chrome.get_login_forms():
+        for login_form in self.chrome.get_login_forms(self.exact_css_selectors):
             yield login_form
 
     @staticmethod

--- a/w3af/core/controllers/chrome/login/find_form/strategies/password_and_parent.py
+++ b/w3af/core/controllers/chrome/login/find_form/strategies/password_and_parent.py
@@ -19,12 +19,11 @@ along with w3af; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 """
+from w3af.core.controllers.chrome.login.find_form.strategies.base_find_form_strategy import \
+    BaseFindFormStrategy
 
 
-class PasswordAndParentStrategy(object):
-    def __init__(self, chrome, debugging_id):
-        self.chrome = chrome
-        self.debugging_id = debugging_id
+class PasswordAndParentStrategy(BaseFindFormStrategy):
 
     def find_forms(self):
         """
@@ -32,8 +31,9 @@ class PasswordAndParentStrategy(object):
 
         :return: Yield forms which are identified by the strategy algorithm
         """
-        for login_form in self.chrome.get_login_forms_without_form_tags():
+        for login_form in self.chrome.get_login_forms_without_form_tags(self.exact_css_selectors):
             yield login_form
 
-    def get_name(self):
+    @staticmethod
+    def get_name():
         return 'PasswordAndParent'

--- a/w3af/core/controllers/chrome/login/submit_form/main.py
+++ b/w3af/core/controllers/chrome/login/submit_form/main.py
@@ -31,7 +31,7 @@ class FormSubmitter(object):
     STRATEGIES = [
         PressEnterStrategy,
         PressTabEnterStrategy,
-        #FormInputSubmitStrategy
+        FormInputSubmitStrategy
     ]
 
     def __init__(self, chrome, form, login_form_url, username, password, debugging_id):

--- a/w3af/core/controllers/chrome/login/submit_form/main.py
+++ b/w3af/core/controllers/chrome/login/submit_form/main.py
@@ -19,6 +19,8 @@ along with w3af; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 """
+import traceback
+
 from w3af.core.controllers import output_manager as om
 
 from w3af.core.controllers.chrome.login.submit_form.strategies.press_enter import PressEnterStrategy
@@ -91,3 +93,4 @@ class FormSubmitter(object):
                 e,
                 self.debugging_id)
         om.out.debug(msg % args)
+        om.out.error(traceback.format_exc())

--- a/w3af/core/controllers/chrome/login/submit_form/main.py
+++ b/w3af/core/controllers/chrome/login/submit_form/main.py
@@ -31,7 +31,7 @@ class FormSubmitter(object):
     STRATEGIES = [
         PressEnterStrategy,
         PressTabEnterStrategy,
-        FormInputSubmitStrategy
+        # FormInputSubmitStrategy
     ]
 
     def __init__(self, chrome, form, login_form_url, username, password, debugging_id):

--- a/w3af/core/data/options/option_list.py
+++ b/w3af/core/data/options/option_list.py
@@ -35,6 +35,18 @@ class OptionList(object):
         self._internal_opt_list.append(option)
     append = add
 
+    def pop(self, option):
+        """
+        DANGEROUS!!
+        You will probably want to deepcopy the OptionList instance before
+        modifying it with this method to don't block the user from accessing options
+        again.
+        """
+        if not isinstance(option, int):
+            option_names = [item.get_name() for item in self._internal_opt_list]
+            option = option_names.index(option)
+        return self._internal_opt_list.pop(option)
+
     def __len__(self):
         return len(self._internal_opt_list)
 

--- a/w3af/plugins/auth/autocomplete_js.py
+++ b/w3af/plugins/auth/autocomplete_js.py
@@ -42,6 +42,7 @@ class autocomplete_js(autocomplete):
         # default values for autocomplete_js options
         self.username_field_css_selector = ''
         self.login_button_css_selector = ''
+        self.login_form_activator_css_selector = ''
 
         self._login_form = None
         self._http_traffic_queue = None
@@ -223,6 +224,7 @@ class autocomplete_js(autocomplete):
         css_selectors = {
             'username_input': self.username_field_css_selector,
             'login_button': self.login_button_css_selector,
+            'form_activator': self.login_form_activator_css_selector,
         }
 
         for form in form_finder.find_forms(css_selectors):
@@ -328,6 +330,13 @@ class autocomplete_js(autocomplete):
                 "the login button field. When provided the scanner is not going "
                 "to try to detect the login button in an automated way"
             ),
+            (
+                'login_form_activator_css_selector',
+                self.login_form_activator_css_selector,
+                STRING,
+                "(Optional) Exact CSS selector for the element which needs to be "
+                "clicked to show login form."
+            )
         ]
         for option in autocomplete_js_options:
             option_list.add(opt_factory(
@@ -346,6 +355,9 @@ class autocomplete_js(autocomplete):
         ).get_value()
         self.login_button_css_selector = options_list_copy.pop(
             'login_button_css_selector'
+        ).get_value()
+        self.login_form_activator_css_selector = options_list_copy.pop(
+            'login_form_activator_css_selector'
         ).get_value()
         super(autocomplete_js, self).set_options(options_list_copy)
 
@@ -366,6 +378,10 @@ class autocomplete_js(autocomplete):
         plugin to use those selectors in case when it can't find username field
         or login button automatically.
 
+        If the page requires to click on something to show the login form you
+        can set `login_form_activator_css_selector` and scanner will use it
+        find and click on element
+
         The following configurable parameters exist:
             - username
             - password
@@ -374,4 +390,5 @@ class autocomplete_js(autocomplete):
             - check_string
             - username_field_css_selector
             - login_button_css_selector
+            - login_form_activator_css_selector
         """

--- a/w3af/plugins/auth/autocomplete_js.py
+++ b/w3af/plugins/auth/autocomplete_js.py
@@ -137,7 +137,12 @@ class autocomplete_js(autocomplete):
         :param chrome: The chrome instance to use during login
         :return: True if login was successful
         """
-        raise NotImplementedError
+        form_submit_strategy = self._find_form_submit_strategy(chrome, self._login_form)
+        if form_submit_strategy is None:
+            return False
+        self._login_form.set_submit_strategy(form_submit_strategy)
+        self._log_debug('Identified valid login form: %s' % self._login_form)
+        return True
 
     def _login_and_save_form(self, chrome):
         """

--- a/w3af/plugins/auth/autocomplete_js.py
+++ b/w3af/plugins/auth/autocomplete_js.py
@@ -279,7 +279,6 @@ class autocomplete_js(autocomplete):
 
         try:
             chrome.load_url(self.check_url)
-            chrome.chrome_conn.Page.reload(ignore_cache=True)
             loaded = chrome.wait_for_load()
             if not loaded:
                 msg = 'Failed to load %s in chrome for autocomplete_js'

--- a/w3af/plugins/auth/autocomplete_js.py
+++ b/w3af/plugins/auth/autocomplete_js.py
@@ -317,16 +317,16 @@ class autocomplete_js(autocomplete):
                 self.username_field_css_selector,
                 STRING,
                 "(Optional) Exact CSS selector which will be used to retrieve "
-                "the username input field. If provided then w3af won't try "
-                "to detect input field automatically."
+                "the username input field. When provided the scanner is not going"
+                " to try to detect the input field in an automated way"
             ),
             (
                 'login_button_css_selector',
                 self.login_button_css_selector,
                 STRING,
                 "(Optional) Exact CSS selector which will be used to retrieve "
-                "the login button field. If provided then w3af won't try "
-                "to detect button automatically."
+                "the login button field. When provided the scanner is not going "
+                "to try to detect the login button in an automated way"
             ),
         ]
         for option in autocomplete_js_options:
@@ -360,7 +360,11 @@ class autocomplete_js(autocomplete):
         
         The plugin loads the `login_form_url` to obtain the login form, automatically
         identifies the inputs where the `username` and `password` should be entered,
-        and then submits the form by clicking on the login button.
+        and then submits the form by clicking on the login button. You can specify
+        the exact CSS selectors (like ".login > input #password") in
+        `username_filed_css_selector` and `login_button_css_selector` to force
+        plugin to use those selectors in case when it can't find username field
+        or login button automatically.
 
         The following configurable parameters exist:
             - username
@@ -368,4 +372,6 @@ class autocomplete_js(autocomplete):
             - login_form_url
             - check_url
             - check_string
+            - username_field_css_selector
+            - login_button_css_selector
         """

--- a/w3af/plugins/auth/autocomplete_js.py
+++ b/w3af/plugins/auth/autocomplete_js.py
@@ -81,6 +81,7 @@ class autocomplete_js(autocomplete):
         return True
 
     def _handle_authentication_success(self):
+        self._login_result_log.append(True)
         #
         # Logging
         #


### PR DESCRIPTION
- autocomplete_js is able to detect more inputs/buttons with common CSS selectors (check `dom_analyzer.js`)
- autocomplete_js runs `has_active_session` method using the same chrome instance as `_do_login()` method to preserve already logged in instance
- added new options to autocomplete_js config, so user can provide his own CSS selectors to find login button and username input. It should cover edge cases when we're not able to automatically detect them:
  * `username_field_css_selector`
  * `login_button_css_selector`
- added new option to autocomplete_js config, so user can provide CSS selector for button that needs to be clicked to display login form:
  * `login_form_activator_css_selector`