### PR TITLE
w3af/core/data/

### DIFF
--- a/w3af/core/data/db/startup_cfg.py
+++ b/w3af/core/data/db/startup_cfg.py
@@ -19,7 +19,7 @@ along with w3af; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 """
 import os
-import ConfigParser
+import configparser
 
 from datetime import datetime, date, timedelta
 


### PR DESCRIPTION
Uses the correct case. Also makes the Python3 Failure message work.