### PR TITLE
Update keys.py — fix types for SSH2

### DIFF
--- a/w3af/plugins/grep/keys.py
+++ b/w3af/plugins/grep/keys.py
@@ -59,8 +59,8 @@ class keys(GrepPlugin):
             ('ecdsa-sha2-nistp256', ('EC-PUBLIC', PUBLIC)),
             
             # SSH2
-            ('---- BEGIN SSH2 PUBLIC KEY ----', ('SSH2-PRIVATE', PRIVATE)),
-            ('---- BEGIN SSH2 PRIVATE KEY ----', ('SSH2-PUBLIC', PUBLIC)),
+            ('---- BEGIN SSH2 PRIVATE KEY ----', ('SSH2-PRIVATE', PRIVATE)),
+            ('---- BEGIN SSH2 PUBLIC KEY ----', ('SSH2-PUBLIC', PUBLIC)),
 
             # ed25519 (OpenSSH)
             ('-----BEGIN OPENSSH PRIVATE KEY-----', ('ED25519-SSH-PRIVATE', PRIVATE)),


### PR DESCRIPTION
Swap incorrect categorizations of SSH2 PRIVATE and SSH2 PUBLIC keys.